### PR TITLE
Specify suhosin needs to be disabled (or at least phar whitelisted)

### DIFF
--- a/index.md
+++ b/index.md
@@ -10,6 +10,7 @@ Requirements
 
 * PHP >= 5.3
 * WordPress >= 3.3
+* Either suhosin disabled or suhosin.executor.include.whitelist="phar" in your /etc/php5/conf.d/suhosin.ini or php.ini file
 
 Installing
 ==========


### PR DESCRIPTION
If you follow the "phar" instructions on the homepage, and have suhosin enabled (for instance in Debian default setup), nothing works. No error what so ever, nothing.

This is because suhosin won't allow Phar to function, but doesn't seem to bother to log that to stdout or stderr.

So let's clarify that on the homepage!
