### PR TITLE
Bug fix for home directories with spaces

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -42,8 +42,8 @@ else
 	}
 fi
 
-mkdir -p $INSTALL_DIR
-cd $INSTALL_DIR
+mkdir -p "$INSTALL_DIR"
+cd "$INSTALL_DIR"
 
 # install Composer
 if [ ! -x composer.phar ]; then


### PR DESCRIPTION
My home dir on Windows has a space in it so when I run the install script (in Git Bash) WP-CLI gets dumped into a weird location.

Change not tested on *nix.
