### PR TITLE
Better way to install wp-cli Edit

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -23,10 +23,12 @@ EOB
 	which php || which php-cli || return 1
 }
 
+INSTALL_DIR=$1
 if [ -z "$INSTALL_DIR" ]; then
 	INSTALL_DIR=$HOME/.composer
 fi
 
+VERSION=$2
 if [ -z "$VERSION" ]; then
 	VERSION='@stable'
 fi


### PR DESCRIPTION
Old Way To Change Installation Dir:

``` bash
curl http://wp-cli.org/installer.sh > installer.sh
INSTALL_DIR='/usr/share/wp-cli' sudo bash installer.sh
```

Now Better way

``` bash
curl http://wp-cli.org/installer.sh | sudo bash -s /usr/share/wp-cli
```
