### PR TITLE
Resolve horrific installation-based security issue

### DIFF
--- a/index.md
+++ b/index.md
@@ -15,7 +15,7 @@ title: Command line interface for WordPress
 Just execute the following command in your terminal:
 
 ```
-curl http://wp-cli.org/installer.sh | bash
+curl https://raw.github.com/wp-cli/wp-cli.github.com/master/installer.sh | bash
 ```
 
 Make sure to read the instructions.


### PR DESCRIPTION
Expecting HTTP traffic to not be mangled, especially when a potential attacker
knows users are planning on piping it directly to bash, is a horrifying idea.

Instead, link to the HTTPS version hosted on github.com. Same outcome, less
horribleness.
