### PR TITLE
Adding alternate location based on older versions of MAMP

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -2,6 +2,7 @@
 
 find_php() {
 	read -r -d '' AMP_PATHS <<EOB
+/Applications/MAMP/bin/php5.3/bin/php
 /Applications/MAMP/bin/php/*/bin/php
 /Applications/xampp/xamppfiles/bin/php
 /opt/lampp/bin/php


### PR DESCRIPTION
General installer always failed for me. Working now.
