### PR TITLE
detect if Composer failed to include any required packages

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -72,12 +72,11 @@ command -v bin/wp > /dev/null || {
 	echo "Installing WP-CLI in $INSTALL_DIR"
 	echo "-----------------"
 	$COMPOSER require --prefer-source wp-cli/wp-cli="$VERSION"
-	echo "$OUTPUT"
-	echo
 	if [ $? -ne 0 ]; then
 	   echo "WP-CLI was not successfully installed."
 	   exit 1
 	else
+	   echo
 	   echo "WP-CLI files have been successfully installed."
    	fi
    fi


### PR DESCRIPTION
This script displayed success message, even if Composer command failed
(e.g. "
Installation failed, reverting ./composer.json to its original content. 
PFXPHP-CLI files have been successfully installed. 
To test PFXPHP-CLI ...
").  
This update prints success/failure message depending on Composer output.
