### PR TITLE
Update index.md

### DIFF
--- a/index.md
+++ b/index.md
@@ -15,8 +15,9 @@ title: Command line interface for WordPress
 First, download [wp-cli.phar](https://raw.github.com/wp-cli/builds/gh-pages/phar/wp-cli.phar) using `wget` or `curl`. For example:
 
 ~~~
-curl -L https://raw.github.com/wp-cli/builds/gh-pages/phar/wp-cli.phar > wp-cli.phar
+curl -kL https://raw.github.com/wp-cli/builds/gh-pages/phar/wp-cli.phar > wp-cli.phar
 ~~~
+
 
 Then, check if it works:
 


### PR DESCRIPTION
adding -k option to curl to ignore cert warning (cert identifies itself as www.github.com when called as raw.github.com - but we need to call as raw to get the raw output).
