### PR TITLE
The suggested path should be '/usr/local/bin/' and not '/usr/bin/' as '/...

### DIFF
--- a/index.md
+++ b/index.md
@@ -29,7 +29,7 @@ To be able to type just `wp`, instead of `php wp-cli.phar`, you need to make the
 
 ~~~
 chmod +x wp-cli.phar
-sudo mv wp-cli.phar /usr/bin/wp
+sudo mv wp-cli.phar /usr/local/bin/wp
 ~~~
 
 Now try running `wp --info`.


### PR DESCRIPTION
The suggested path should be '/usr/local/bin/' and not '/usr/bin/' as '/usr/local/' is for user installed items like this.

More details in this Unix question & answer thread on Stack Exchange. http://unix.stackexchange.com/questions/4186/what-is-usr-local-bin-came-across-it-in-an-script-installation-for-applescript
