### PR TITLE
check certs and save with same name

### DIFF
--- a/index.md
+++ b/index.md
@@ -15,7 +15,7 @@ title: Command line interface for WordPress
 First, download [wp-cli.phar](https://raw.github.com/wp-cli/builds/gh-pages/phar/wp-cli.phar) using `wget` or `curl`. For example:
 
 ~~~
-curl -kL https://raw.github.com/wp-cli/builds/gh-pages/phar/wp-cli.phar > wp-cli.phar
+curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
 ~~~
 
 


### PR DESCRIPTION
curl should check for certs (hence no -k) and not follow redirects (no -L) to improve security a bit, and with -O it saves the a file with the remote name on the current directory, no redirect needed
