### PR TITLE
Expose internals on the site with phpDocumentor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,8 @@ Gemfile.lock
 composer.lock
 vendor
 _drafts/
+
+# PHPdocumentor
+/phpdoc
+/output
+phpDocumentor.phar

--- a/Phakefile.php
+++ b/Phakefile.php
@@ -124,6 +124,27 @@ task( 'param-list', function( $app ) {
 	file_put_contents( '_includes/param-list.html', $out );
 });
 
+desc( 'Generate pages for classes based on PHPdoc.' );
+task( 'class-list', function( $app ) {
+
+	$wp = invoke_wp_cli( 'wp cli info --format=json', $app );
+	$class_dir_path = $wp['wp_cli_dir_path'] . '/php';
+	if ( ! is_dir( $class_dir_path ) ) {
+		echo "WP-CLI must be available as a non-Phar install.\n";
+		die(1);
+	}
+
+	ob_start();
+	@system( "./phpDocumentor.phar -d $class_dir_path -t 'phpdoc' --template='xml'" );
+	ob_get_clean();
+
+	if ( ! is_dir( './phpdoc' ) ) {
+		echo "Something broke generating the PHPdoc XML file.\n";
+		die(1);
+	}
+
+});
+
 desc( 'Build the site.' );
-task( 'default', 'cmd-list', 'param-list' );
+task( 'default', 'cmd-list', 'param-list', 'class-list' );
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 
 2. Install dev dependencies with `composer install --dev`
 
-3. Build:
+3. Install phpDocumentor with `wget http://phpdoc.org/phpDocumentor.phar; chmod +x phpDocumentor.phar`
+
+4. Build:
 
 ```bash
 vendor/bin/phake


### PR DESCRIPTION
* [x] Use phpDocumentor to build XML output of the class data
* [ ] Create a template for representing a standard class
* [ ] Create a template for representing the list of classes
* [ ] Hook up Phake to build our site templates.

See https://github.com/wp-cli/wp-cli/issues/1045