### PR TITLE
Update index.md example 1 gives an error.

### DIFF
--- a/commands/cron/event/schedule/index.md
+++ b/commands/cron/event/schedule/index.md
@@ -21,8 +21,6 @@ title: 'wp cron event schedule'
 
 ### EXAMPLES
 
-    wp cron event schedule cron_test
-
     wp cron event schedule cron_test now hourly
 
     wp cron event schedule cron_test '+1 hour' --foo=1 --bar=2


### PR DESCRIPTION
wp cron event schedule cron_test is expecting <next-run> and will not run without it.
