### PR TITLE
Update MAMP instruction link to point to a more robust answer

### DIFF
--- a/index.md
+++ b/index.md
@@ -38,7 +38,7 @@ Upgrade using the same procedure.
 
 <h3 id="mamp">MAMP</h3>
 
-If you're using MAMP, you will probably get a MySQL error, because the `php` found in your PATH is not the same as the PHP used by MAMP. Here is one way to [fix it](http://stackoverflow.com/a/10653443/97998).
+If you're using MAMP, you will probably get a MySQL error, because the `php` found in your PATH is not the same as the PHP used by MAMP. Here is one way to [fix it](http://stackoverflow.com/a/29990624/333625).
 
 More resources:
 


### PR DESCRIPTION
I came up with a better solution for using MAMP’s `php` and `mysql` executables from the command line and posted an answer with it in the same Stack Overflow question that this page links to. The new solution by default exports the latest MAMP PHP version, rather than hardcoding the version number, so it’s more likely to allow people to actually get WP-CLI working in a MAMP environment.