### PR TITLE
Fix typo of `wp menu item remove`

### DIFF
--- a/commands/menu/item/delete/index.md
+++ b/commands/menu/item/delete/index.md
@@ -12,7 +12,7 @@ title: 'wp menu item delete'
 
 ### EXAMPLES
 
-    wp menu item remove 45
+    wp menu item delete 45
 
 ### GLOBAL PARAMETERS
 


### PR DESCRIPTION
The correct command is not `remove` but `delete`.