### PR TITLE
Menu item alignment is off.

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -16,7 +16,7 @@
 
 	<body>
 
-		<header>
+		<header class="cf">
 		<div class="container">
 			<h1><a href="/">WP-CLI</a></h1>
 			<h2>A command line interface for WordPress</h2>

--- a/assets/css/stylesheet.css
+++ b/assets/css/stylesheet.css
@@ -311,6 +311,7 @@ footer {
 	list-style: none;
 }
 .main-nav li {
+	float: left;
 	text-align: center;
 	margin: 0;
 }


### PR DESCRIPTION
Currently:  https://dl.dropboxusercontent.com/s/00bvrmjht41vxz8/2015-09-08%20at%204.35%20PM.png
In this commit:  https://dl.dropboxusercontent.com/s/1g18iz4ly67npyh/2015-09-08%20at%204.36%20PM.png

Changes: float the menu items to the left, the social icons to the right. This causes the header element to not clear its children, so add header.cf to fix that.