### PR TITLE
Fix widget list command example

### DIFF
--- a/commands/widget/list/index.md
+++ b/commands/widget/list/index.md
@@ -29,7 +29,7 @@ There are no optionally available fields.
 
 ### EXAMPLES
 
-    wp sidebar widget list &lt;sidebar-id&gt; --fields=name --format=csv
+    wp widget list sidebar-1 --fields=name --format=csv
 
 ### GLOBAL PARAMETERS
 


### PR DESCRIPTION
Incorrectly using `sidebar` in the `widget list` command example, and the `&lt;sidebar-id&gt;` bit is not actually an example of anything.

<img width="824" alt="screen shot 2015-12-23 at 11 47 27 pm" src="https://cloud.githubusercontent.com/assets/522158/11990188/a514e6b8-a9cf-11e5-8e0d-ed571fd348d1.png">

http://wp-cli.org/commands/widget/list/