### PR TITLE
Stylistic changes to individual internal API doc pagse

### DIFF
--- a/Phakefile.php
+++ b/Phakefile.php
@@ -168,8 +168,12 @@ task( 'internal-api-list', function( $app ) {
 	foreach( $categories as $name => $apis ) {
 		$out .= '## ' . $name . PHP_EOL . PHP_EOL;
 		$out .= render( 'internal-api-list.mustache', array( 'apis' => $apis ) );
-		foreach( $apis as $api ) {
+		foreach( $apis as $i => $api ) {
 			$api['category'] = $name;
+			$api['related'] = $apis;
+			unset( $api['related'][ $i ] );
+			$api['related'] = array_values( $api['related'] );
+			$api['has_related'] = ! empty( $api['related'] );
 			$api_doc = render( 'internal-api.mustache', $api );
 			$path = "docs/internal-api/{$api['api_slug']}";
 			if ( ! is_dir( $path ) ) {
@@ -177,6 +181,7 @@ task( 'internal-api-list', function( $app ) {
 			}
 			file_put_contents( "$path/index.md", $api_doc );
 		}
+		$out .= PHP_EOL . PHP_EOL;
 	}
 
 	file_put_contents( '_includes/internal-api-list.html', $out );

--- a/_includes/internal-api-list.html
+++ b/_includes/internal-api-list.html
@@ -2,79 +2,75 @@
 
 ## Output
 
-
-<strong><a href="/docs/internal-api/wp-cli-utils-format-items/">WP_CLI\Utils\format_items()</a></strong>
-
-Render a collection of items as an ASCII table, JSON, CSV, YAML, list of ids, or count.
+<ul>
 
 
-<strong><a href="/docs/internal-api/wp-cli-line/">WP_CLI::line()</a></strong>
-
-Display a message in the CLI and end with a newline.
+<li><strong><a href="/docs/internal-api/wp-cli-utils-format-items/">WP_CLI\Utils\format_items()</a></strong> - Render a collection of items as an ASCII table, JSON, CSV, YAML, list of ids, or count.</li>
 
 
-<strong><a href="/docs/internal-api/wp-cli-log/">WP_CLI::log()</a></strong>
-
-Log an informational message.
+<li><strong><a href="/docs/internal-api/wp-cli-line/">WP_CLI::line()</a></strong> - Display a message in the CLI and end with a newline.</li>
 
 
-<strong><a href="/docs/internal-api/wp-cli-success/">WP_CLI::success()</a></strong>
-
-Display a success in the CLI and end with a newline.
+<li><strong><a href="/docs/internal-api/wp-cli-log/">WP_CLI::log()</a></strong> - Log an informational message.</li>
 
 
-<strong><a href="/docs/internal-api/wp-cli-debug/">WP_CLI::debug()</a></strong>
-
-Display debug message prefixed with &quot;Debug: &quot; when `--debug` is used.
+<li><strong><a href="/docs/internal-api/wp-cli-success/">WP_CLI::success()</a></strong> - Display a success in the CLI and end with a newline.</li>
 
 
-<strong><a href="/docs/internal-api/wp-cli-warning/">WP_CLI::warning()</a></strong>
-
-Display warning message prefixed with &quot;Warning: &quot;.
+<li><strong><a href="/docs/internal-api/wp-cli-debug/">WP_CLI::debug()</a></strong> - Display debug message prefixed with &quot;Debug: &quot; when `--debug` is used.</li>
 
 
-<strong><a href="/docs/internal-api/wp-cli-error/">WP_CLI::error()</a></strong>
+<li><strong><a href="/docs/internal-api/wp-cli-warning/">WP_CLI::warning()</a></strong> - Display warning message prefixed with &quot;Warning: &quot;.</li>
 
-Display error message prefixed with &quot;Error: &quot; and exits script.
+
+<li><strong><a href="/docs/internal-api/wp-cli-error/">WP_CLI::error()</a></strong> - Display error message prefixed with &quot;Error: &quot; and exits script.</li>
+
+
+</ul>
+
 
 ## Input
 
+<ul>
 
-<strong><a href="/docs/internal-api/wp-cli-read-value/">WP_CLI::read_value()</a></strong>
 
-Read a value, from various formats.
+<li><strong><a href="/docs/internal-api/wp-cli-read-value/">WP_CLI::read_value()</a></strong> - Read a value, from various formats.</li>
+
+
+</ul>
+
 
 ## Execution
 
+<ul>
 
-<strong><a href="/docs/internal-api/wp-cli-launch/">WP_CLI::launch()</a></strong>
 
-Launch an arbitrary external process that takes over I/O.
+<li><strong><a href="/docs/internal-api/wp-cli-launch/">WP_CLI::launch()</a></strong> - Launch an arbitrary external process that takes over I/O.</li>
+
+
+</ul>
+
 
 ## Misc
 
-
-<strong><a href="/docs/internal-api/wp-cli-utils-write-csv/">WP_CLI\Utils\write_csv()</a></strong>
-
-Write data as CSV to a given file.
+<ul>
 
 
-<strong><a href="/docs/internal-api/wp-cli-utils-get-named-sem-ver/">WP_CLI\Utils\get_named_sem_ver()</a></strong>
-
-Compare two version strings to get the named semantic version.
+<li><strong><a href="/docs/internal-api/wp-cli-utils-write-csv/">WP_CLI\Utils\write_csv()</a></strong> - Write data as CSV to a given file.</li>
 
 
-<strong><a href="/docs/internal-api/wp-cli-utils-get-flag-value/">WP_CLI\Utils\get_flag_value()</a></strong>
-
-Return the flag value or, if it's not set, the $default value.
+<li><strong><a href="/docs/internal-api/wp-cli-utils-get-named-sem-ver/">WP_CLI\Utils\get_named_sem_ver()</a></strong> - Compare two version strings to get the named semantic version.</li>
 
 
-<strong><a href="/docs/internal-api/wp-cli-utils-get-temp-dir/">WP_CLI\Utils\get_temp_dir()</a></strong>
-
-Get the temp directory, and let the user know if it isn't writable.
+<li><strong><a href="/docs/internal-api/wp-cli-utils-get-flag-value/">WP_CLI\Utils\get_flag_value()</a></strong> - Return the flag value or, if it's not set, the $default value.</li>
 
 
-<strong><a href="/docs/internal-api/wp-cli-error-multi-line/">WP_CLI::error_multi_line()</a></strong>
+<li><strong><a href="/docs/internal-api/wp-cli-utils-get-temp-dir/">WP_CLI\Utils\get_temp_dir()</a></strong> - Get the temp directory, and let the user know if it isn't writable.</li>
 
-Display an error in the CLI and end with a newline.
+
+<li><strong><a href="/docs/internal-api/wp-cli-error-multi-line/">WP_CLI::error_multi_line()</a></strong> - Display an error in the CLI and end with a newline.</li>
+
+
+</ul>
+
 

--- a/_templates/internal-api-list.mustache
+++ b/_templates/internal-api-list.mustache
@@ -1,7 +1,9 @@
+<ul>
+
 {{#apis}}
 
-<strong><a href="/docs/internal-api/{{api_slug}}/">{{full_name}}()</a></strong>
-
-{{phpdoc.short_description}}
+<li><strong><a href="/docs/internal-api/{{api_slug}}/">{{full_name}}()</a></strong> - {{phpdoc.short_description}}</li>
 
 {{/apis}}
+
+</ul>

--- a/_templates/internal-api.mustache
+++ b/_templates/internal-api.mustache
@@ -7,9 +7,11 @@ title: {{full_name}}()
 
 ## {{full_name}}()
 
-    {{signature}}
-
 {{phpdoc.short_description}}
+
+### Usage
+
+    {{signature}}
 
 <div>
 {{#phpdoc.parameters.param}}
@@ -20,5 +22,10 @@ title: {{full_name}}()
 {{/phpdoc.parameters.return}}
 </div>
 
-{{{phpdoc.long_description}}}
+{{#phpdoc.long_description}}
 
+### Notes
+
+{{phpdoc.long_description}}
+
+{{/phpdoc.long_description}}

--- a/_templates/internal-api.mustache
+++ b/_templates/internal-api.mustache
@@ -9,6 +9,8 @@ title: {{full_name}}()
 
 {{phpdoc.short_description}}
 
+***
+
 ### Usage
 
     {{signature}}
@@ -24,8 +26,33 @@ title: {{full_name}}()
 
 {{#phpdoc.long_description}}
 
+***
+
 ### Notes
 
-{{phpdoc.long_description}}
+{{{phpdoc.long_description}}}
 
 {{/phpdoc.long_description}}
+
+{{#has_related}}
+
+***
+
+### Related
+
+<ul>
+
+{{/has_related}}
+
+{{#related}}
+
+<li><strong><a href="/docs/internal-api/{{api_slug}}/">{{full_name}}()</a></strong> - {{phpdoc.short_description}}</li>
+
+{{/related}}
+
+{{#has_related}}
+
+</ul>
+
+{{/has_related}}
+

--- a/docs/internal-api/wp-cli-debug/index.md
+++ b/docs/internal-api/wp-cli-debug/index.md
@@ -7,13 +7,18 @@ title: WP_CLI::debug()
 
 ## WP_CLI::debug()
 
-    WP_CLI::debug( $message )
-
 Display debug message prefixed with &quot;Debug: &quot; when `--debug` is used.
+
+### Usage
+
+    WP_CLI::debug( $message )
 
 <div>
 <strong>$message</strong> (string) <br />
 </div>
+
+
+### Notes
 
 Helpful for optionally showing greater detail when needed. Debug message
 is written to STDERR, and includes script execution time.

--- a/docs/internal-api/wp-cli-debug/index.md
+++ b/docs/internal-api/wp-cli-debug/index.md
@@ -9,6 +9,8 @@ title: WP_CLI::debug()
 
 Display debug message prefixed with &quot;Debug: &quot; when `--debug` is used.
 
+***
+
 ### Usage
 
     WP_CLI::debug( $message )
@@ -18,8 +20,42 @@ Display debug message prefixed with &quot;Debug: &quot; when `--debug` is used.
 </div>
 
 
+***
+
 ### Notes
 
 Helpful for optionally showing greater detail when needed. Debug message
 is written to STDERR, and includes script execution time.
+
+
+
+***
+
+### Related
+
+<ul>
+
+
+
+<li><strong><a href="/docs/internal-api/wp-cli-utils-format-items/">WP_CLI\Utils\format_items()</a></strong> - Render a collection of items as an ASCII table, JSON, CSV, YAML, list of ids, or count.</li>
+
+
+<li><strong><a href="/docs/internal-api/wp-cli-line/">WP_CLI::line()</a></strong> - Display a message in the CLI and end with a newline.</li>
+
+
+<li><strong><a href="/docs/internal-api/wp-cli-log/">WP_CLI::log()</a></strong> - Log an informational message.</li>
+
+
+<li><strong><a href="/docs/internal-api/wp-cli-success/">WP_CLI::success()</a></strong> - Display a success in the CLI and end with a newline.</li>
+
+
+<li><strong><a href="/docs/internal-api/wp-cli-warning/">WP_CLI::warning()</a></strong> - Display warning message prefixed with &quot;Warning: &quot;.</li>
+
+
+<li><strong><a href="/docs/internal-api/wp-cli-error/">WP_CLI::error()</a></strong> - Display error message prefixed with &quot;Error: &quot; and exits script.</li>
+
+
+
+</ul>
+
 

--- a/docs/internal-api/wp-cli-error-multi-line/index.md
+++ b/docs/internal-api/wp-cli-error-multi-line/index.md
@@ -7,13 +7,13 @@ title: WP_CLI::error_multi_line()
 
 ## WP_CLI::error_multi_line()
 
-    WP_CLI::error_multi_line( $message_lines )
-
 Display an error in the CLI and end with a newline.
+
+### Usage
+
+    WP_CLI::error_multi_line( $message_lines )
 
 <div>
 <strong>$message</strong> (array) each element from the array will be printed on its own line<br />
 </div>
-
-
 

--- a/docs/internal-api/wp-cli-error-multi-line/index.md
+++ b/docs/internal-api/wp-cli-error-multi-line/index.md
@@ -9,6 +9,8 @@ title: WP_CLI::error_multi_line()
 
 Display an error in the CLI and end with a newline.
 
+***
+
 ### Usage
 
     WP_CLI::error_multi_line( $message_lines )
@@ -16,4 +18,30 @@ Display an error in the CLI and end with a newline.
 <div>
 <strong>$message</strong> (array) each element from the array will be printed on its own line<br />
 </div>
+
+
+
+***
+
+### Related
+
+<ul>
+
+
+
+<li><strong><a href="/docs/internal-api/wp-cli-utils-write-csv/">WP_CLI\Utils\write_csv()</a></strong> - Write data as CSV to a given file.</li>
+
+
+<li><strong><a href="/docs/internal-api/wp-cli-utils-get-named-sem-ver/">WP_CLI\Utils\get_named_sem_ver()</a></strong> - Compare two version strings to get the named semantic version.</li>
+
+
+<li><strong><a href="/docs/internal-api/wp-cli-utils-get-flag-value/">WP_CLI\Utils\get_flag_value()</a></strong> - Return the flag value or, if it's not set, the $default value.</li>
+
+
+<li><strong><a href="/docs/internal-api/wp-cli-utils-get-temp-dir/">WP_CLI\Utils\get_temp_dir()</a></strong> - Get the temp directory, and let the user know if it isn't writable.</li>
+
+
+
+</ul>
+
 

--- a/docs/internal-api/wp-cli-error/index.md
+++ b/docs/internal-api/wp-cli-error/index.md
@@ -7,15 +7,20 @@ title: WP_CLI::error()
 
 ## WP_CLI::error()
 
-    WP_CLI::error( $message, $exit = true )
-
 Display error message prefixed with &quot;Error: &quot; and exits script.
+
+### Usage
+
+    WP_CLI::error( $message, $exit = true )
 
 <div>
 <strong>$message</strong> (string|WP_Error) Message to write to STDERR.<br />
 <strong>$exit</strong> (boolean|integer) True defaults to exit(1).<br />
 <strong>@return</strong> (null) <br /></p>
 </div>
+
+
+### Notes
 
 Error message is written to STDERR. Defaults to halting
 script execution with return code 1.

--- a/docs/internal-api/wp-cli-error/index.md
+++ b/docs/internal-api/wp-cli-error/index.md
@@ -9,6 +9,8 @@ title: WP_CLI::error()
 
 Display error message prefixed with &quot;Error: &quot; and exits script.
 
+***
+
 ### Usage
 
     WP_CLI::error( $message, $exit = true )
@@ -19,6 +21,8 @@ Display error message prefixed with &quot;Error: &quot; and exits script.
 <strong>@return</strong> (null) <br /></p>
 </div>
 
+
+***
 
 ### Notes
 
@@ -31,4 +35,36 @@ script execution with return code 1.
         WP_CLI::error( 'The object cache could not be flushed.' );
     }
     
+
+
+
+***
+
+### Related
+
+<ul>
+
+
+
+<li><strong><a href="/docs/internal-api/wp-cli-utils-format-items/">WP_CLI\Utils\format_items()</a></strong> - Render a collection of items as an ASCII table, JSON, CSV, YAML, list of ids, or count.</li>
+
+
+<li><strong><a href="/docs/internal-api/wp-cli-line/">WP_CLI::line()</a></strong> - Display a message in the CLI and end with a newline.</li>
+
+
+<li><strong><a href="/docs/internal-api/wp-cli-log/">WP_CLI::log()</a></strong> - Log an informational message.</li>
+
+
+<li><strong><a href="/docs/internal-api/wp-cli-success/">WP_CLI::success()</a></strong> - Display a success in the CLI and end with a newline.</li>
+
+
+<li><strong><a href="/docs/internal-api/wp-cli-debug/">WP_CLI::debug()</a></strong> - Display debug message prefixed with &quot;Debug: &quot; when `--debug` is used.</li>
+
+
+<li><strong><a href="/docs/internal-api/wp-cli-warning/">WP_CLI::warning()</a></strong> - Display warning message prefixed with &quot;Warning: &quot;.</li>
+
+
+
+</ul>
+
 

--- a/docs/internal-api/wp-cli-launch/index.md
+++ b/docs/internal-api/wp-cli-launch/index.md
@@ -7,9 +7,11 @@ title: WP_CLI::launch()
 
 ## WP_CLI::launch()
 
-    WP_CLI::launch( $command, $exit_on_error = true, $return_detailed = array() )
-
 Launch an arbitrary external process that takes over I/O.
+
+### Usage
+
+    WP_CLI::launch( $command, $exit_on_error = true, $return_detailed = array() )
 
 <div>
 <strong>Command</strong> (string) to call<br />
@@ -17,6 +19,4 @@ Launch an arbitrary external process that takes over I/O.
 <strong>Whether</strong> (bool) to return an exit status (default) or detailed execution results.<br />
 <strong>@return</strong> (int|ProcessRun) command exit status, or a ProcessRun instance<br /></p>
 </div>
-
-
 

--- a/docs/internal-api/wp-cli-launch/index.md
+++ b/docs/internal-api/wp-cli-launch/index.md
@@ -9,6 +9,8 @@ title: WP_CLI::launch()
 
 Launch an arbitrary external process that takes over I/O.
 
+***
+
 ### Usage
 
     WP_CLI::launch( $command, $exit_on_error = true, $return_detailed = array() )
@@ -19,4 +21,8 @@ Launch an arbitrary external process that takes over I/O.
 <strong>Whether</strong> (bool) to return an exit status (default) or detailed execution results.<br />
 <strong>@return</strong> (int|ProcessRun) command exit status, or a ProcessRun instance<br /></p>
 </div>
+
+
+
+
 

--- a/docs/internal-api/wp-cli-line/index.md
+++ b/docs/internal-api/wp-cli-line/index.md
@@ -9,6 +9,8 @@ title: WP_CLI::line()
 
 Display a message in the CLI and end with a newline.
 
+***
+
 ### Usage
 
     WP_CLI::line( $message = '' )
@@ -19,7 +21,41 @@ Display a message in the CLI and end with a newline.
 </div>
 
 
+***
+
 ### Notes
 
 Ignores `--quiet` flag. To respect, use `WP_CLI::log()`
+
+
+
+***
+
+### Related
+
+<ul>
+
+
+
+<li><strong><a href="/docs/internal-api/wp-cli-utils-format-items/">WP_CLI\Utils\format_items()</a></strong> - Render a collection of items as an ASCII table, JSON, CSV, YAML, list of ids, or count.</li>
+
+
+<li><strong><a href="/docs/internal-api/wp-cli-log/">WP_CLI::log()</a></strong> - Log an informational message.</li>
+
+
+<li><strong><a href="/docs/internal-api/wp-cli-success/">WP_CLI::success()</a></strong> - Display a success in the CLI and end with a newline.</li>
+
+
+<li><strong><a href="/docs/internal-api/wp-cli-debug/">WP_CLI::debug()</a></strong> - Display debug message prefixed with &quot;Debug: &quot; when `--debug` is used.</li>
+
+
+<li><strong><a href="/docs/internal-api/wp-cli-warning/">WP_CLI::warning()</a></strong> - Display warning message prefixed with &quot;Warning: &quot;.</li>
+
+
+<li><strong><a href="/docs/internal-api/wp-cli-error/">WP_CLI::error()</a></strong> - Display error message prefixed with &quot;Error: &quot; and exits script.</li>
+
+
+
+</ul>
+
 

--- a/docs/internal-api/wp-cli-line/index.md
+++ b/docs/internal-api/wp-cli-line/index.md
@@ -7,14 +7,19 @@ title: WP_CLI::line()
 
 ## WP_CLI::line()
 
-    WP_CLI::line( $message = '' )
-
 Display a message in the CLI and end with a newline.
+
+### Usage
+
+    WP_CLI::line( $message = '' )
 
 <div>
 <strong>$message</strong> (string) Message to display to the end user.<br />
 <strong>@return</strong> (null) <br /></p>
 </div>
+
+
+### Notes
 
 Ignores `--quiet` flag. To respect, use `WP_CLI::log()`
 

--- a/docs/internal-api/wp-cli-log/index.md
+++ b/docs/internal-api/wp-cli-log/index.md
@@ -9,6 +9,8 @@ title: WP_CLI::log()
 
 Log an informational message.
 
+***
+
 ### Usage
 
     WP_CLI::log( $message )
@@ -16,4 +18,36 @@ Log an informational message.
 <div>
 <strong>$message</strong> (string) <br />
 </div>
+
+
+
+***
+
+### Related
+
+<ul>
+
+
+
+<li><strong><a href="/docs/internal-api/wp-cli-utils-format-items/">WP_CLI\Utils\format_items()</a></strong> - Render a collection of items as an ASCII table, JSON, CSV, YAML, list of ids, or count.</li>
+
+
+<li><strong><a href="/docs/internal-api/wp-cli-line/">WP_CLI::line()</a></strong> - Display a message in the CLI and end with a newline.</li>
+
+
+<li><strong><a href="/docs/internal-api/wp-cli-success/">WP_CLI::success()</a></strong> - Display a success in the CLI and end with a newline.</li>
+
+
+<li><strong><a href="/docs/internal-api/wp-cli-debug/">WP_CLI::debug()</a></strong> - Display debug message prefixed with &quot;Debug: &quot; when `--debug` is used.</li>
+
+
+<li><strong><a href="/docs/internal-api/wp-cli-warning/">WP_CLI::warning()</a></strong> - Display warning message prefixed with &quot;Warning: &quot;.</li>
+
+
+<li><strong><a href="/docs/internal-api/wp-cli-error/">WP_CLI::error()</a></strong> - Display error message prefixed with &quot;Error: &quot; and exits script.</li>
+
+
+
+</ul>
+
 

--- a/docs/internal-api/wp-cli-log/index.md
+++ b/docs/internal-api/wp-cli-log/index.md
@@ -7,13 +7,13 @@ title: WP_CLI::log()
 
 ## WP_CLI::log()
 
-    WP_CLI::log( $message )
-
 Log an informational message.
+
+### Usage
+
+    WP_CLI::log( $message )
 
 <div>
 <strong>$message</strong> (string) <br />
 </div>
-
-
 

--- a/docs/internal-api/wp-cli-read-value/index.md
+++ b/docs/internal-api/wp-cli-read-value/index.md
@@ -7,14 +7,14 @@ title: WP_CLI::read_value()
 
 ## WP_CLI::read_value()
 
-    WP_CLI::read_value( $raw_value, $assoc_args = array() )
-
 Read a value, from various formats.
+
+### Usage
+
+    WP_CLI::read_value( $raw_value, $assoc_args = array() )
 
 <div>
 <strong>$value</strong> (mixed) <br />
 <strong>$assoc_args</strong> (array) <br />
 </div>
-
-
 

--- a/docs/internal-api/wp-cli-read-value/index.md
+++ b/docs/internal-api/wp-cli-read-value/index.md
@@ -9,6 +9,8 @@ title: WP_CLI::read_value()
 
 Read a value, from various formats.
 
+***
+
 ### Usage
 
     WP_CLI::read_value( $raw_value, $assoc_args = array() )
@@ -17,4 +19,8 @@ Read a value, from various formats.
 <strong>$value</strong> (mixed) <br />
 <strong>$assoc_args</strong> (array) <br />
 </div>
+
+
+
+
 

--- a/docs/internal-api/wp-cli-success/index.md
+++ b/docs/internal-api/wp-cli-success/index.md
@@ -9,6 +9,8 @@ title: WP_CLI::success()
 
 Display a success in the CLI and end with a newline.
 
+***
+
 ### Usage
 
     WP_CLI::success( $message )
@@ -16,4 +18,36 @@ Display a success in the CLI and end with a newline.
 <div>
 <strong>$message</strong> (string) <br />
 </div>
+
+
+
+***
+
+### Related
+
+<ul>
+
+
+
+<li><strong><a href="/docs/internal-api/wp-cli-utils-format-items/">WP_CLI\Utils\format_items()</a></strong> - Render a collection of items as an ASCII table, JSON, CSV, YAML, list of ids, or count.</li>
+
+
+<li><strong><a href="/docs/internal-api/wp-cli-line/">WP_CLI::line()</a></strong> - Display a message in the CLI and end with a newline.</li>
+
+
+<li><strong><a href="/docs/internal-api/wp-cli-log/">WP_CLI::log()</a></strong> - Log an informational message.</li>
+
+
+<li><strong><a href="/docs/internal-api/wp-cli-debug/">WP_CLI::debug()</a></strong> - Display debug message prefixed with &quot;Debug: &quot; when `--debug` is used.</li>
+
+
+<li><strong><a href="/docs/internal-api/wp-cli-warning/">WP_CLI::warning()</a></strong> - Display warning message prefixed with &quot;Warning: &quot;.</li>
+
+
+<li><strong><a href="/docs/internal-api/wp-cli-error/">WP_CLI::error()</a></strong> - Display error message prefixed with &quot;Error: &quot; and exits script.</li>
+
+
+
+</ul>
+
 

--- a/docs/internal-api/wp-cli-success/index.md
+++ b/docs/internal-api/wp-cli-success/index.md
@@ -7,13 +7,13 @@ title: WP_CLI::success()
 
 ## WP_CLI::success()
 
-    WP_CLI::success( $message )
-
 Display a success in the CLI and end with a newline.
+
+### Usage
+
+    WP_CLI::success( $message )
 
 <div>
 <strong>$message</strong> (string) <br />
 </div>
-
-
 

--- a/docs/internal-api/wp-cli-utils-format-items/index.md
+++ b/docs/internal-api/wp-cli-utils-format-items/index.md
@@ -9,6 +9,8 @@ title: WP_CLI\Utils\format_items()
 
 Render a collection of items as an ASCII table, JSON, CSV, YAML, list of ids, or count.
 
+***
+
 ### Usage
 
     WP_CLI\Utils\format_items( $format, $items, $fields )
@@ -19,4 +21,36 @@ Render a collection of items as an ASCII table, JSON, CSV, YAML, list of ids, or
 <strong>$fields</strong> (array|string) Named fields for each item of data. Can be array or comma-separated list<br />
 <strong>@return</strong> (null) <br /></p>
 </div>
+
+
+
+***
+
+### Related
+
+<ul>
+
+
+
+<li><strong><a href="/docs/internal-api/wp-cli-line/">WP_CLI::line()</a></strong> - Display a message in the CLI and end with a newline.</li>
+
+
+<li><strong><a href="/docs/internal-api/wp-cli-log/">WP_CLI::log()</a></strong> - Log an informational message.</li>
+
+
+<li><strong><a href="/docs/internal-api/wp-cli-success/">WP_CLI::success()</a></strong> - Display a success in the CLI and end with a newline.</li>
+
+
+<li><strong><a href="/docs/internal-api/wp-cli-debug/">WP_CLI::debug()</a></strong> - Display debug message prefixed with &quot;Debug: &quot; when `--debug` is used.</li>
+
+
+<li><strong><a href="/docs/internal-api/wp-cli-warning/">WP_CLI::warning()</a></strong> - Display warning message prefixed with &quot;Warning: &quot;.</li>
+
+
+<li><strong><a href="/docs/internal-api/wp-cli-error/">WP_CLI::error()</a></strong> - Display error message prefixed with &quot;Error: &quot; and exits script.</li>
+
+
+
+</ul>
+
 

--- a/docs/internal-api/wp-cli-utils-format-items/index.md
+++ b/docs/internal-api/wp-cli-utils-format-items/index.md
@@ -7,9 +7,11 @@ title: WP_CLI\Utils\format_items()
 
 ## WP_CLI\Utils\format_items()
 
-    WP_CLI\Utils\format_items( $format, $items, $fields )
-
 Render a collection of items as an ASCII table, JSON, CSV, YAML, list of ids, or count.
+
+### Usage
+
+    WP_CLI\Utils\format_items( $format, $items, $fields )
 
 <div>
 <strong>$format</strong> (string) Format to use: 'table', 'json', 'csv', 'yaml', 'ids', 'count'<br />
@@ -17,6 +19,4 @@ Render a collection of items as an ASCII table, JSON, CSV, YAML, list of ids, or
 <strong>$fields</strong> (array|string) Named fields for each item of data. Can be array or comma-separated list<br />
 <strong>@return</strong> (null) <br /></p>
 </div>
-
-
 

--- a/docs/internal-api/wp-cli-utils-get-flag-value/index.md
+++ b/docs/internal-api/wp-cli-utils-get-flag-value/index.md
@@ -7,9 +7,11 @@ title: WP_CLI\Utils\get_flag_value()
 
 ## WP_CLI\Utils\get_flag_value()
 
-    WP_CLI\Utils\get_flag_value( $assoc_args, $flag, $default = array() )
-
 Return the flag value or, if it's not set, the $default value.
+
+### Usage
+
+    WP_CLI\Utils\get_flag_value( $assoc_args, $flag, $default = array() )
 
 <div>
 <strong>$assoc_args</strong> (array) Arguments array.<br />
@@ -17,6 +19,4 @@ Return the flag value or, if it's not set, the $default value.
 <strong>$default</strong> (mixed) Default value for the flag. Default: NULL<br />
 <strong>@return</strong> (mixed) <br /></p>
 </div>
-
-
 

--- a/docs/internal-api/wp-cli-utils-get-flag-value/index.md
+++ b/docs/internal-api/wp-cli-utils-get-flag-value/index.md
@@ -9,6 +9,8 @@ title: WP_CLI\Utils\get_flag_value()
 
 Return the flag value or, if it's not set, the $default value.
 
+***
+
 ### Usage
 
     WP_CLI\Utils\get_flag_value( $assoc_args, $flag, $default = array() )
@@ -19,4 +21,30 @@ Return the flag value or, if it's not set, the $default value.
 <strong>$default</strong> (mixed) Default value for the flag. Default: NULL<br />
 <strong>@return</strong> (mixed) <br /></p>
 </div>
+
+
+
+***
+
+### Related
+
+<ul>
+
+
+
+<li><strong><a href="/docs/internal-api/wp-cli-utils-write-csv/">WP_CLI\Utils\write_csv()</a></strong> - Write data as CSV to a given file.</li>
+
+
+<li><strong><a href="/docs/internal-api/wp-cli-utils-get-named-sem-ver/">WP_CLI\Utils\get_named_sem_ver()</a></strong> - Compare two version strings to get the named semantic version.</li>
+
+
+<li><strong><a href="/docs/internal-api/wp-cli-utils-get-temp-dir/">WP_CLI\Utils\get_temp_dir()</a></strong> - Get the temp directory, and let the user know if it isn't writable.</li>
+
+
+<li><strong><a href="/docs/internal-api/wp-cli-error-multi-line/">WP_CLI::error_multi_line()</a></strong> - Display an error in the CLI and end with a newline.</li>
+
+
+
+</ul>
+
 

--- a/docs/internal-api/wp-cli-utils-get-named-sem-ver/index.md
+++ b/docs/internal-api/wp-cli-utils-get-named-sem-ver/index.md
@@ -9,6 +9,8 @@ title: WP_CLI\Utils\get_named_sem_ver()
 
 Compare two version strings to get the named semantic version.
 
+***
+
 ### Usage
 
     WP_CLI\Utils\get_named_sem_ver( $new_version, $original_version )
@@ -18,4 +20,30 @@ Compare two version strings to get the named semantic version.
 <strong>$original_version</strong> (string) <br />
 <strong>@return</strong> (string) 'major', 'minor', 'patch'<br /></p>
 </div>
+
+
+
+***
+
+### Related
+
+<ul>
+
+
+
+<li><strong><a href="/docs/internal-api/wp-cli-utils-write-csv/">WP_CLI\Utils\write_csv()</a></strong> - Write data as CSV to a given file.</li>
+
+
+<li><strong><a href="/docs/internal-api/wp-cli-utils-get-flag-value/">WP_CLI\Utils\get_flag_value()</a></strong> - Return the flag value or, if it's not set, the $default value.</li>
+
+
+<li><strong><a href="/docs/internal-api/wp-cli-utils-get-temp-dir/">WP_CLI\Utils\get_temp_dir()</a></strong> - Get the temp directory, and let the user know if it isn't writable.</li>
+
+
+<li><strong><a href="/docs/internal-api/wp-cli-error-multi-line/">WP_CLI::error_multi_line()</a></strong> - Display an error in the CLI and end with a newline.</li>
+
+
+
+</ul>
+
 

--- a/docs/internal-api/wp-cli-utils-get-named-sem-ver/index.md
+++ b/docs/internal-api/wp-cli-utils-get-named-sem-ver/index.md
@@ -7,15 +7,15 @@ title: WP_CLI\Utils\get_named_sem_ver()
 
 ## WP_CLI\Utils\get_named_sem_ver()
 
-    WP_CLI\Utils\get_named_sem_ver( $new_version, $original_version )
-
 Compare two version strings to get the named semantic version.
+
+### Usage
+
+    WP_CLI\Utils\get_named_sem_ver( $new_version, $original_version )
 
 <div>
 <strong>$new_version</strong> (string) <br />
 <strong>$original_version</strong> (string) <br />
 <strong>@return</strong> (string) 'major', 'minor', 'patch'<br /></p>
 </div>
-
-
 

--- a/docs/internal-api/wp-cli-utils-get-temp-dir/index.md
+++ b/docs/internal-api/wp-cli-utils-get-temp-dir/index.md
@@ -7,13 +7,13 @@ title: WP_CLI\Utils\get_temp_dir()
 
 ## WP_CLI\Utils\get_temp_dir()
 
-    WP_CLI\Utils\get_temp_dir()
-
 Get the temp directory, and let the user know if it isn't writable.
+
+### Usage
+
+    WP_CLI\Utils\get_temp_dir()
 
 <div>
 <strong>@return</strong> (string) <br /></p>
 </div>
-
-
 

--- a/docs/internal-api/wp-cli-utils-get-temp-dir/index.md
+++ b/docs/internal-api/wp-cli-utils-get-temp-dir/index.md
@@ -9,6 +9,8 @@ title: WP_CLI\Utils\get_temp_dir()
 
 Get the temp directory, and let the user know if it isn't writable.
 
+***
+
 ### Usage
 
     WP_CLI\Utils\get_temp_dir()
@@ -16,4 +18,30 @@ Get the temp directory, and let the user know if it isn't writable.
 <div>
 <strong>@return</strong> (string) <br /></p>
 </div>
+
+
+
+***
+
+### Related
+
+<ul>
+
+
+
+<li><strong><a href="/docs/internal-api/wp-cli-utils-write-csv/">WP_CLI\Utils\write_csv()</a></strong> - Write data as CSV to a given file.</li>
+
+
+<li><strong><a href="/docs/internal-api/wp-cli-utils-get-named-sem-ver/">WP_CLI\Utils\get_named_sem_ver()</a></strong> - Compare two version strings to get the named semantic version.</li>
+
+
+<li><strong><a href="/docs/internal-api/wp-cli-utils-get-flag-value/">WP_CLI\Utils\get_flag_value()</a></strong> - Return the flag value or, if it's not set, the $default value.</li>
+
+
+<li><strong><a href="/docs/internal-api/wp-cli-error-multi-line/">WP_CLI::error_multi_line()</a></strong> - Display an error in the CLI and end with a newline.</li>
+
+
+
+</ul>
+
 

--- a/docs/internal-api/wp-cli-utils-write-csv/index.md
+++ b/docs/internal-api/wp-cli-utils-write-csv/index.md
@@ -9,6 +9,8 @@ title: WP_CLI\Utils\write_csv()
 
 Write data as CSV to a given file.
 
+***
+
 ### Usage
 
     WP_CLI\Utils\write_csv( $fd, $rows, $headers = array() )
@@ -18,4 +20,30 @@ Write data as CSV to a given file.
 <strong>$rows</strong> (array) Array of rows to output<br />
 <strong>$headers</strong> (array) List of CSV columns (optional)<br />
 </div>
+
+
+
+***
+
+### Related
+
+<ul>
+
+
+
+<li><strong><a href="/docs/internal-api/wp-cli-utils-get-named-sem-ver/">WP_CLI\Utils\get_named_sem_ver()</a></strong> - Compare two version strings to get the named semantic version.</li>
+
+
+<li><strong><a href="/docs/internal-api/wp-cli-utils-get-flag-value/">WP_CLI\Utils\get_flag_value()</a></strong> - Return the flag value or, if it's not set, the $default value.</li>
+
+
+<li><strong><a href="/docs/internal-api/wp-cli-utils-get-temp-dir/">WP_CLI\Utils\get_temp_dir()</a></strong> - Get the temp directory, and let the user know if it isn't writable.</li>
+
+
+<li><strong><a href="/docs/internal-api/wp-cli-error-multi-line/">WP_CLI::error_multi_line()</a></strong> - Display an error in the CLI and end with a newline.</li>
+
+
+
+</ul>
+
 

--- a/docs/internal-api/wp-cli-utils-write-csv/index.md
+++ b/docs/internal-api/wp-cli-utils-write-csv/index.md
@@ -7,15 +7,15 @@ title: WP_CLI\Utils\write_csv()
 
 ## WP_CLI\Utils\write_csv()
 
-    WP_CLI\Utils\write_csv( $fd, $rows, $headers = array() )
-
 Write data as CSV to a given file.
+
+### Usage
+
+    WP_CLI\Utils\write_csv( $fd, $rows, $headers = array() )
 
 <div>
 <strong>$fd</strong> (resource) File descriptor<br />
 <strong>$rows</strong> (array) Array of rows to output<br />
 <strong>$headers</strong> (array) List of CSV columns (optional)<br />
 </div>
-
-
 

--- a/docs/internal-api/wp-cli-warning/index.md
+++ b/docs/internal-api/wp-cli-warning/index.md
@@ -9,6 +9,8 @@ title: WP_CLI::warning()
 
 Display warning message prefixed with &quot;Warning: &quot;.
 
+***
+
 ### Usage
 
     WP_CLI::warning( $message )
@@ -19,17 +21,51 @@ Display warning message prefixed with &quot;Warning: &quot;.
 </div>
 
 
+***
+
 ### Notes
 
 Warning message is written to STDERR.
 
 
     # `wp plugin activate` skips activation when plugin is network active.
-    $status = $this-&gt;get_status( $plugin-&gt;file );
+    $status = $this->get_status( $plugin->file );
     // Network-active is the highest level of activation status
     if ( 'active-network' === $status ) {
-    	WP_CLI::warning( &quot;Plugin '{$plugin-&gt;name}' is already network active.&quot; );
+    	WP_CLI::warning( "Plugin '{$plugin->name}' is already network active." );
     	continue;
     }
     
+
+
+
+***
+
+### Related
+
+<ul>
+
+
+
+<li><strong><a href="/docs/internal-api/wp-cli-utils-format-items/">WP_CLI\Utils\format_items()</a></strong> - Render a collection of items as an ASCII table, JSON, CSV, YAML, list of ids, or count.</li>
+
+
+<li><strong><a href="/docs/internal-api/wp-cli-line/">WP_CLI::line()</a></strong> - Display a message in the CLI and end with a newline.</li>
+
+
+<li><strong><a href="/docs/internal-api/wp-cli-log/">WP_CLI::log()</a></strong> - Log an informational message.</li>
+
+
+<li><strong><a href="/docs/internal-api/wp-cli-success/">WP_CLI::success()</a></strong> - Display a success in the CLI and end with a newline.</li>
+
+
+<li><strong><a href="/docs/internal-api/wp-cli-debug/">WP_CLI::debug()</a></strong> - Display debug message prefixed with &quot;Debug: &quot; when `--debug` is used.</li>
+
+
+<li><strong><a href="/docs/internal-api/wp-cli-error/">WP_CLI::error()</a></strong> - Display error message prefixed with &quot;Error: &quot; and exits script.</li>
+
+
+
+</ul>
+
 

--- a/docs/internal-api/wp-cli-warning/index.md
+++ b/docs/internal-api/wp-cli-warning/index.md
@@ -7,23 +7,28 @@ title: WP_CLI::warning()
 
 ## WP_CLI::warning()
 
-    WP_CLI::warning( $message )
-
 Display warning message prefixed with &quot;Warning: &quot;.
+
+### Usage
+
+    WP_CLI::warning( $message )
 
 <div>
 <strong>$message</strong> (string) Message to write to STDERR.<br />
 <strong>@return</strong> (null) <br /></p>
 </div>
 
+
+### Notes
+
 Warning message is written to STDERR.
 
 
     # `wp plugin activate` skips activation when plugin is network active.
-    $status = $this->get_status( $plugin->file );
+    $status = $this-&gt;get_status( $plugin-&gt;file );
     // Network-active is the highest level of activation status
     if ( 'active-network' === $status ) {
-    	WP_CLI::warning( "Plugin '{$plugin->name}' is already network active." );
+    	WP_CLI::warning( &quot;Plugin '{$plugin-&gt;name}' is already network active.&quot; );
     	continue;
     }
     


### PR DESCRIPTION
* Break page into sections.
* Include related APIs based on category.

See https://github.com/wp-cli/wp-cli/issues/1045