### PR TITLE
Add a /docs/ landing page

### DIFF
--- a/Phakefile.php
+++ b/Phakefile.php
@@ -209,6 +209,51 @@ task( 'internal-api-list', function( $app ) {
 	file_put_contents( '_includes/internal-api-list.html', $out );
 });
 
+desc( 'Update the /docs/ page.' );
+task( 'doc-list', function( $app ){
+	$docs = array(
+		'Guides'       => array(),
+		'References'   => array(),
+		'Contributing' => array(),
+		'Misc'         => array(),
+	);
+	foreach( glob( __DIR__ . '/docs/*/index.md' ) as $file ) {
+		$contents = file_get_contents( $file );
+		$parts = explode( '---', $contents );
+		$header = $parts[1];
+		preg_match( '#category:\s(.+)#', $header, $matches );
+		if ( ! empty( $matches[1] ) && array_key_exists( $matches[1], $docs ) ) {
+			$category = $matches[1];
+		} else {
+			$category = 'Misc';
+		}
+		preg_match( '#title:\s(.+)#', $header, $matches );
+		$title = ! empty( $matches[1] ) ? $matches[1] : '';
+		preg_match( '#description:\s(.+)#', $header, $matches );
+		$description = ! empty( $matches[1] ) ? $matches[1] : '';
+		$docs[ $category ][] = array(
+			'path'        => basename( dirname( $file ) ),
+			'title'       => $title,
+			'description' => $description,
+		);
+	}
+	$out = '';
+	foreach( $docs as $category => $cat_docs ) {
+		$out .= '<h3>' . $category . '</h3>' . PHP_EOL . PHP_EOL;
+		$out .= '<ul>' . PHP_EOL;
+		foreach( $cat_docs as $cat_doc ) {
+			$out .= '<li><a href="/docs/' . $cat_doc['path'] . '/"><strong>' . $cat_doc['title'] . '</strong></a>';
+			if ( ! empty( $cat_doc['description'] ) ) {
+				$out .= ' - ' . $cat_doc['description'];
+			}
+			$out .= '</li>' . PHP_EOL;
+		}
+		$out .= '</ul>' . PHP_EOL . PHP_EOL;
+	}
+
+	file_put_contents( '_includes/doc-list.html', $out );
+});
+
 desc( 'Build the site.' );
-task( 'default', 'cmd-list', 'param-list', 'internal-api-list' );
+task( 'default', 'cmd-list', 'param-list', 'internal-api-list', 'doc-list' );
 

--- a/_includes/doc-list.html
+++ b/_includes/doc-list.html
@@ -1,0 +1,22 @@
+<h3>Guides</h3>
+
+<ul>
+<li><a href="/docs/installing/"><strong>Installing</strong></a> - Recommended and alternative installation mechanisms.</li>
+</ul>
+
+<h3>References</h3>
+
+<ul>
+<li><a href="/docs/internal-api/"><strong>Internal API</strong></a> - Stable utilities considered safe to use in community commands.</li>
+</ul>
+
+<h3>Contributing</h3>
+
+<ul>
+</ul>
+
+<h3>Misc</h3>
+
+<ul>
+</ul>
+

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -12,6 +12,7 @@
 		<link rel="alternate" type="application/atom+xml" href="/atom.xml" title="Atom Feed">
 
 		<title>{{ page.title }} | WP-CLI</title>
+		<meta name="description" content="{{ page.description }}">
 	</head>
 
 	{% if page.display_global_parameters %}

--- a/_layouts/doc.html
+++ b/_layouts/doc.html
@@ -1,6 +1,9 @@
 {% include header.html %}
 
 {% capture page_url %}{{ page.url | remove:'index.html' }}{% endcapture %}
+
+<span style="float:right;"><a href="https://github.com/wp-cli/wp-cli.github.com/edit/master/{{page.path}}">Edit</a></span>
+
 {% if page_url != '/docs/' %}
 <a href="/docs/">Docs</a> &raquo; {{ page.category }}
 {% endif %}

--- a/_layouts/doc.html
+++ b/_layouts/doc.html
@@ -1,0 +1,10 @@
+{% include header.html %}
+
+{% capture page_url %}{{ page.url | remove:'index.html' }}{% endcapture %}
+{% if page_url != '/docs/' %}
+<a href="/docs/">Docs</a> &raquo; {{ page.category }}
+{% endif %}
+
+{{ content }}
+
+{% include footer.html %}

--- a/_templates/internal-api.mustache
+++ b/_templates/internal-api.mustache
@@ -3,7 +3,7 @@ layout: default
 title: {{full_name}}()
 ---
 
-<a href="/docs/internal-api/">Internal API</a> &raquo; {{category}}
+<a href="/docs/">Docs</a> &raquo; <a href="/docs/internal-api/">Internal API</a> &raquo; {{category}}
 
 ## {{full_name}}()
 

--- a/_templates/internal-api.mustache
+++ b/_templates/internal-api.mustache
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: {{full_name}}()
+description: {{phpdoc.short_description}}
 ---
 
 <a href="/docs/">Docs</a> &raquo; <a href="/docs/internal-api/">Internal API</a> &raquo; {{category}}

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,13 @@
+---
+layout: doc
+title: Documentation
+description: Helpful guides and resources for using WP-CLI.
+---
+
+## Documentation
+
+Here are some helpful guides and resources for using WP-CLI.
+
+Can't find what you're looking for? [Open an issue](https://github.com/wp-cli/wp-cli/issues) to request improvements.
+
+{% include doc-list.html %}

--- a/docs/installing/index.md
+++ b/docs/installing/index.md
@@ -1,6 +1,8 @@
 ---
-layout: default
+layout: doc
 title: Installing
+category: Guides
+description: Recommended and alternative installation mechanisms.
 ---
 
 ## Recommended Installation

--- a/docs/internal-api/index.md
+++ b/docs/internal-api/index.md
@@ -1,6 +1,8 @@
 ---
-layout: default
+layout: doc
 title: Internal API
+category: References
+description: Stable utilities considered safe to use in community commands.
 ---
 
 ## Internal API

--- a/docs/internal-api/wp-cli-add-command/index.md
+++ b/docs/internal-api/wp-cli-add-command/index.md
@@ -3,7 +3,7 @@ layout: default
 title: WP_CLI::add_command()
 ---
 
-<a href="/docs/internal-api/">Internal API</a> &raquo; Registration
+<a href="/docs/">Docs</a> &raquo; <a href="/docs/internal-api/">Internal API</a> &raquo; Registration
 
 ## WP_CLI::add_command()
 

--- a/docs/internal-api/wp-cli-add-command/index.md
+++ b/docs/internal-api/wp-cli-add-command/index.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: WP_CLI::add_command()
+description: Register a command to WP-CLI.
 ---
 
 <a href="/docs/">Docs</a> &raquo; <a href="/docs/internal-api/">Internal API</a> &raquo; Registration

--- a/docs/internal-api/wp-cli-add-hook/index.md
+++ b/docs/internal-api/wp-cli-add-hook/index.md
@@ -3,7 +3,7 @@ layout: default
 title: WP_CLI::add_hook()
 ---
 
-<a href="/docs/internal-api/">Internal API</a> &raquo; Registration
+<a href="/docs/">Docs</a> &raquo; <a href="/docs/internal-api/">Internal API</a> &raquo; Registration
 
 ## WP_CLI::add_hook()
 

--- a/docs/internal-api/wp-cli-add-hook/index.md
+++ b/docs/internal-api/wp-cli-add-hook/index.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: WP_CLI::add_hook()
+description: Schedule a callback to be executed at a certain point.
 ---
 
 <a href="/docs/">Docs</a> &raquo; <a href="/docs/internal-api/">Internal API</a> &raquo; Registration

--- a/docs/internal-api/wp-cli-confirm/index.md
+++ b/docs/internal-api/wp-cli-confirm/index.md
@@ -3,7 +3,7 @@ layout: default
 title: WP_CLI::confirm()
 ---
 
-<a href="/docs/internal-api/">Internal API</a> &raquo; Input
+<a href="/docs/">Docs</a> &raquo; <a href="/docs/internal-api/">Internal API</a> &raquo; Input
 
 ## WP_CLI::confirm()
 

--- a/docs/internal-api/wp-cli-confirm/index.md
+++ b/docs/internal-api/wp-cli-confirm/index.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: WP_CLI::confirm()
+description: Ask for confirmation before running a destructive operation.
 ---
 
 <a href="/docs/">Docs</a> &raquo; <a href="/docs/internal-api/">Internal API</a> &raquo; Input

--- a/docs/internal-api/wp-cli-debug/index.md
+++ b/docs/internal-api/wp-cli-debug/index.md
@@ -3,7 +3,7 @@ layout: default
 title: WP_CLI::debug()
 ---
 
-<a href="/docs/internal-api/">Internal API</a> &raquo; Output
+<a href="/docs/">Docs</a> &raquo; <a href="/docs/internal-api/">Internal API</a> &raquo; Output
 
 ## WP_CLI::debug()
 

--- a/docs/internal-api/wp-cli-debug/index.md
+++ b/docs/internal-api/wp-cli-debug/index.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: WP_CLI::debug()
+description: Display debug message prefixed with &quot;Debug: &quot; when `--debug` is used.
 ---
 
 <a href="/docs/">Docs</a> &raquo; <a href="/docs/internal-api/">Internal API</a> &raquo; Output

--- a/docs/internal-api/wp-cli-do-hook/index.md
+++ b/docs/internal-api/wp-cli-do-hook/index.md
@@ -3,7 +3,7 @@ layout: default
 title: WP_CLI::do_hook()
 ---
 
-<a href="/docs/internal-api/">Internal API</a> &raquo; Registration
+<a href="/docs/">Docs</a> &raquo; <a href="/docs/internal-api/">Internal API</a> &raquo; Registration
 
 ## WP_CLI::do_hook()
 

--- a/docs/internal-api/wp-cli-do-hook/index.md
+++ b/docs/internal-api/wp-cli-do-hook/index.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: WP_CLI::do_hook()
+description: Execute callbacks registered to a given hook.
 ---
 
 <a href="/docs/">Docs</a> &raquo; <a href="/docs/internal-api/">Internal API</a> &raquo; Registration

--- a/docs/internal-api/wp-cli-error-multi-line/index.md
+++ b/docs/internal-api/wp-cli-error-multi-line/index.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: WP_CLI::error_multi_line()
+description: Display a multi-line error message in a red box. Doesn't exit script.
 ---
 
 <a href="/docs/">Docs</a> &raquo; <a href="/docs/internal-api/">Internal API</a> &raquo; Output

--- a/docs/internal-api/wp-cli-error-multi-line/index.md
+++ b/docs/internal-api/wp-cli-error-multi-line/index.md
@@ -3,7 +3,7 @@ layout: default
 title: WP_CLI::error_multi_line()
 ---
 
-<a href="/docs/internal-api/">Internal API</a> &raquo; Output
+<a href="/docs/">Docs</a> &raquo; <a href="/docs/internal-api/">Internal API</a> &raquo; Output
 
 ## WP_CLI::error_multi_line()
 

--- a/docs/internal-api/wp-cli-error/index.md
+++ b/docs/internal-api/wp-cli-error/index.md
@@ -3,7 +3,7 @@ layout: default
 title: WP_CLI::error()
 ---
 
-<a href="/docs/internal-api/">Internal API</a> &raquo; Output
+<a href="/docs/">Docs</a> &raquo; <a href="/docs/internal-api/">Internal API</a> &raquo; Output
 
 ## WP_CLI::error()
 

--- a/docs/internal-api/wp-cli-error/index.md
+++ b/docs/internal-api/wp-cli-error/index.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: WP_CLI::error()
+description: Display error message prefixed with &quot;Error: &quot; and exit script.
 ---
 
 <a href="/docs/">Docs</a> &raquo; <a href="/docs/internal-api/">Internal API</a> &raquo; Output

--- a/docs/internal-api/wp-cli-get-php-binary/index.md
+++ b/docs/internal-api/wp-cli-get-php-binary/index.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: WP_CLI::get_php_binary()
+description: Get the path to the PHP binary used when executing WP-CLI.
 ---
 
 <a href="/docs/">Docs</a> &raquo; <a href="/docs/internal-api/">Internal API</a> &raquo; System

--- a/docs/internal-api/wp-cli-get-php-binary/index.md
+++ b/docs/internal-api/wp-cli-get-php-binary/index.md
@@ -3,7 +3,7 @@ layout: default
 title: WP_CLI::get_php_binary()
 ---
 
-<a href="/docs/internal-api/">Internal API</a> &raquo; System
+<a href="/docs/">Docs</a> &raquo; <a href="/docs/internal-api/">Internal API</a> &raquo; System
 
 ## WP_CLI::get_php_binary()
 

--- a/docs/internal-api/wp-cli-launch-self/index.md
+++ b/docs/internal-api/wp-cli-launch-self/index.md
@@ -3,7 +3,7 @@ layout: default
 title: WP_CLI::launch_self()
 ---
 
-<a href="/docs/internal-api/">Internal API</a> &raquo; Execution
+<a href="/docs/">Docs</a> &raquo; <a href="/docs/internal-api/">Internal API</a> &raquo; Execution
 
 ## WP_CLI::launch_self()
 

--- a/docs/internal-api/wp-cli-launch-self/index.md
+++ b/docs/internal-api/wp-cli-launch-self/index.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: WP_CLI::launch_self()
+description: Run a WP-CLI command in a new process reusing the current runtime arguments.
 ---
 
 <a href="/docs/">Docs</a> &raquo; <a href="/docs/internal-api/">Internal API</a> &raquo; Execution

--- a/docs/internal-api/wp-cli-launch/index.md
+++ b/docs/internal-api/wp-cli-launch/index.md
@@ -3,7 +3,7 @@ layout: default
 title: WP_CLI::launch()
 ---
 
-<a href="/docs/internal-api/">Internal API</a> &raquo; Execution
+<a href="/docs/">Docs</a> &raquo; <a href="/docs/internal-api/">Internal API</a> &raquo; Execution
 
 ## WP_CLI::launch()
 

--- a/docs/internal-api/wp-cli-launch/index.md
+++ b/docs/internal-api/wp-cli-launch/index.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: WP_CLI::launch()
+description: Launch an arbitrary external process that takes over I/O.
 ---
 
 <a href="/docs/">Docs</a> &raquo; <a href="/docs/internal-api/">Internal API</a> &raquo; Execution

--- a/docs/internal-api/wp-cli-line/index.md
+++ b/docs/internal-api/wp-cli-line/index.md
@@ -3,7 +3,7 @@ layout: default
 title: WP_CLI::line()
 ---
 
-<a href="/docs/internal-api/">Internal API</a> &raquo; Output
+<a href="/docs/">Docs</a> &raquo; <a href="/docs/internal-api/">Internal API</a> &raquo; Output
 
 ## WP_CLI::line()
 

--- a/docs/internal-api/wp-cli-line/index.md
+++ b/docs/internal-api/wp-cli-line/index.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: WP_CLI::line()
+description: Display informational message without prefix, and ignore `--quiet`.
 ---
 
 <a href="/docs/">Docs</a> &raquo; <a href="/docs/internal-api/">Internal API</a> &raquo; Output

--- a/docs/internal-api/wp-cli-log/index.md
+++ b/docs/internal-api/wp-cli-log/index.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: WP_CLI::log()
+description: Display informational message without prefix.
 ---
 
 <a href="/docs/">Docs</a> &raquo; <a href="/docs/internal-api/">Internal API</a> &raquo; Output

--- a/docs/internal-api/wp-cli-log/index.md
+++ b/docs/internal-api/wp-cli-log/index.md
@@ -3,7 +3,7 @@ layout: default
 title: WP_CLI::log()
 ---
 
-<a href="/docs/internal-api/">Internal API</a> &raquo; Output
+<a href="/docs/">Docs</a> &raquo; <a href="/docs/internal-api/">Internal API</a> &raquo; Output
 
 ## WP_CLI::log()
 

--- a/docs/internal-api/wp-cli-read-value/index.md
+++ b/docs/internal-api/wp-cli-read-value/index.md
@@ -3,7 +3,7 @@ layout: default
 title: WP_CLI::read_value()
 ---
 
-<a href="/docs/internal-api/">Internal API</a> &raquo; Input
+<a href="/docs/">Docs</a> &raquo; <a href="/docs/internal-api/">Internal API</a> &raquo; Input
 
 ## WP_CLI::read_value()
 

--- a/docs/internal-api/wp-cli-read-value/index.md
+++ b/docs/internal-api/wp-cli-read-value/index.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: WP_CLI::read_value()
+description: Read a value, from various formats.
 ---
 
 <a href="/docs/">Docs</a> &raquo; <a href="/docs/internal-api/">Internal API</a> &raquo; Input

--- a/docs/internal-api/wp-cli-success/index.md
+++ b/docs/internal-api/wp-cli-success/index.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: WP_CLI::success()
+description: Display success message prefixed with &quot;Success: &quot;.
 ---
 
 <a href="/docs/">Docs</a> &raquo; <a href="/docs/internal-api/">Internal API</a> &raquo; Output

--- a/docs/internal-api/wp-cli-success/index.md
+++ b/docs/internal-api/wp-cli-success/index.md
@@ -3,7 +3,7 @@ layout: default
 title: WP_CLI::success()
 ---
 
-<a href="/docs/internal-api/">Internal API</a> &raquo; Output
+<a href="/docs/">Docs</a> &raquo; <a href="/docs/internal-api/">Internal API</a> &raquo; Output
 
 ## WP_CLI::success()
 

--- a/docs/internal-api/wp-cli-utils-format-items/index.md
+++ b/docs/internal-api/wp-cli-utils-format-items/index.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: WP_CLI\Utils\format_items()
+description: Render a collection of items as an ASCII table, JSON, CSV, YAML, list of ids, or count.
 ---
 
 <a href="/docs/">Docs</a> &raquo; <a href="/docs/internal-api/">Internal API</a> &raquo; Output

--- a/docs/internal-api/wp-cli-utils-format-items/index.md
+++ b/docs/internal-api/wp-cli-utils-format-items/index.md
@@ -3,7 +3,7 @@ layout: default
 title: WP_CLI\Utils\format_items()
 ---
 
-<a href="/docs/internal-api/">Internal API</a> &raquo; Output
+<a href="/docs/">Docs</a> &raquo; <a href="/docs/internal-api/">Internal API</a> &raquo; Output
 
 ## WP_CLI\Utils\format_items()
 

--- a/docs/internal-api/wp-cli-utils-get-flag-value/index.md
+++ b/docs/internal-api/wp-cli-utils-get-flag-value/index.md
@@ -3,7 +3,7 @@ layout: default
 title: WP_CLI\Utils\get_flag_value()
 ---
 
-<a href="/docs/internal-api/">Internal API</a> &raquo; Input
+<a href="/docs/">Docs</a> &raquo; <a href="/docs/internal-api/">Internal API</a> &raquo; Input
 
 ## WP_CLI\Utils\get_flag_value()
 

--- a/docs/internal-api/wp-cli-utils-get-flag-value/index.md
+++ b/docs/internal-api/wp-cli-utils-get-flag-value/index.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: WP_CLI\Utils\get_flag_value()
+description: Return the flag value or, if it's not set, the $default value.
 ---
 
 <a href="/docs/">Docs</a> &raquo; <a href="/docs/internal-api/">Internal API</a> &raquo; Input

--- a/docs/internal-api/wp-cli-utils-get-named-sem-ver/index.md
+++ b/docs/internal-api/wp-cli-utils-get-named-sem-ver/index.md
@@ -3,7 +3,7 @@ layout: default
 title: WP_CLI\Utils\get_named_sem_ver()
 ---
 
-<a href="/docs/internal-api/">Internal API</a> &raquo; Misc
+<a href="/docs/">Docs</a> &raquo; <a href="/docs/internal-api/">Internal API</a> &raquo; Misc
 
 ## WP_CLI\Utils\get_named_sem_ver()
 

--- a/docs/internal-api/wp-cli-utils-get-named-sem-ver/index.md
+++ b/docs/internal-api/wp-cli-utils-get-named-sem-ver/index.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: WP_CLI\Utils\get_named_sem_ver()
+description: Compare two version strings to get the named semantic version.
 ---
 
 <a href="/docs/">Docs</a> &raquo; <a href="/docs/internal-api/">Internal API</a> &raquo; Misc

--- a/docs/internal-api/wp-cli-utils-get-temp-dir/index.md
+++ b/docs/internal-api/wp-cli-utils-get-temp-dir/index.md
@@ -3,7 +3,7 @@ layout: default
 title: WP_CLI\Utils\get_temp_dir()
 ---
 
-<a href="/docs/internal-api/">Internal API</a> &raquo; System
+<a href="/docs/">Docs</a> &raquo; <a href="/docs/internal-api/">Internal API</a> &raquo; System
 
 ## WP_CLI\Utils\get_temp_dir()
 

--- a/docs/internal-api/wp-cli-utils-get-temp-dir/index.md
+++ b/docs/internal-api/wp-cli-utils-get-temp-dir/index.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: WP_CLI\Utils\get_temp_dir()
+description: Get the system's temp directory. Warns user if it isn't writable.
 ---
 
 <a href="/docs/">Docs</a> &raquo; <a href="/docs/internal-api/">Internal API</a> &raquo; System

--- a/docs/internal-api/wp-cli-utils-http-request/index.md
+++ b/docs/internal-api/wp-cli-utils-http-request/index.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: WP_CLI\Utils\http_request()
+description: Make a HTTP request to a remote URL.
 ---
 
 <a href="/docs/">Docs</a> &raquo; <a href="/docs/internal-api/">Internal API</a> &raquo; Misc

--- a/docs/internal-api/wp-cli-utils-http-request/index.md
+++ b/docs/internal-api/wp-cli-utils-http-request/index.md
@@ -3,7 +3,7 @@ layout: default
 title: WP_CLI\Utils\http_request()
 ---
 
-<a href="/docs/internal-api/">Internal API</a> &raquo; Misc
+<a href="/docs/">Docs</a> &raquo; <a href="/docs/internal-api/">Internal API</a> &raquo; Misc
 
 ## WP_CLI\Utils\http_request()
 

--- a/docs/internal-api/wp-cli-utils-make-progress-bar/index.md
+++ b/docs/internal-api/wp-cli-utils-make-progress-bar/index.md
@@ -3,7 +3,7 @@ layout: default
 title: WP_CLI\Utils\make_progress_bar()
 ---
 
-<a href="/docs/internal-api/">Internal API</a> &raquo; Output
+<a href="/docs/">Docs</a> &raquo; <a href="/docs/internal-api/">Internal API</a> &raquo; Output
 
 ## WP_CLI\Utils\make_progress_bar()
 

--- a/docs/internal-api/wp-cli-utils-make-progress-bar/index.md
+++ b/docs/internal-api/wp-cli-utils-make-progress-bar/index.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: WP_CLI\Utils\make_progress_bar()
+description: Create a progress bar to display percent completion of a given operation.
 ---
 
 <a href="/docs/">Docs</a> &raquo; <a href="/docs/internal-api/">Internal API</a> &raquo; Output

--- a/docs/internal-api/wp-cli-utils-write-csv/index.md
+++ b/docs/internal-api/wp-cli-utils-write-csv/index.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: WP_CLI\Utils\write_csv()
+description: Write data as CSV to a given file.
 ---
 
 <a href="/docs/">Docs</a> &raquo; <a href="/docs/internal-api/">Internal API</a> &raquo; Misc

--- a/docs/internal-api/wp-cli-utils-write-csv/index.md
+++ b/docs/internal-api/wp-cli-utils-write-csv/index.md
@@ -3,7 +3,7 @@ layout: default
 title: WP_CLI\Utils\write_csv()
 ---
 
-<a href="/docs/internal-api/">Internal API</a> &raquo; Misc
+<a href="/docs/">Docs</a> &raquo; <a href="/docs/internal-api/">Internal API</a> &raquo; Misc
 
 ## WP_CLI\Utils\write_csv()
 

--- a/docs/internal-api/wp-cli-warning/index.md
+++ b/docs/internal-api/wp-cli-warning/index.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: WP_CLI::warning()
+description: Display warning message prefixed with &quot;Warning: &quot;.
 ---
 
 <a href="/docs/">Docs</a> &raquo; <a href="/docs/internal-api/">Internal API</a> &raquo; Output

--- a/docs/internal-api/wp-cli-warning/index.md
+++ b/docs/internal-api/wp-cli-warning/index.md
@@ -3,7 +3,7 @@ layout: default
 title: WP_CLI::warning()
 ---
 
-<a href="/docs/internal-api/">Internal API</a> &raquo; Output
+<a href="/docs/">Docs</a> &raquo; <a href="/docs/internal-api/">Internal API</a> &raquo; Output
 
 ## WP_CLI::warning()
 


### PR DESCRIPTION
Uses Phake to automatically generate the documentation list from subpages

See https://github.com/wp-cli/wp-cli/issues/2508