### PR TITLE
Render documentation page title as part of the template

### DIFF
--- a/_layouts/doc.html
+++ b/_layouts/doc.html
@@ -8,6 +8,8 @@
 <a href="/docs/">Docs</a> &raquo; {{ page.category }}
 {% endif %}
 
+<h1>{{ page.title }}</h1>
+
 {{ content }}
 
 {% include footer.html %}

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,8 +4,6 @@ title: Documentation
 description: Helpful guides and resources for using WP-CLI.
 ---
 
-## Documentation
-
 Here are some helpful guides and resources for using WP-CLI.
 
 Can't find what you're looking for? [Open an issue](https://github.com/wp-cli/wp-cli/issues) to request improvements.

--- a/docs/internal-api/index.md
+++ b/docs/internal-api/index.md
@@ -5,8 +5,6 @@ category: References
 description: Stable utilities considered safe to use in community commands.
 ---
 
-## Internal API
-
 WP-CLI includes a number of utilities which are considered stable and meant to be used by commands.
 
 This also means functions and methods not listed here are considered part of the private API. They may change or disappear at any time.

--- a/docs/philosophy/index.md
+++ b/docs/philosophy/index.md
@@ -5,8 +5,6 @@ category: Contributing
 description: Guidelines which inform project scope, command organization, and behavior.
 ---
 
-# Philosophy
-
 This page contains a list of guidelines that should inform decisions related to scope, command organization and behaviour:
 
 ## Don't assume anything.


### PR DESCRIPTION
See https://github.com/wp-cli/wp-cli/issues/2508