### PR TITLE
Fix formatting of search-replace wildcard example

### DIFF
--- a/commands/search-replace/index.md
+++ b/commands/search-replace/index.md
@@ -30,7 +30,7 @@ change primary key values.
 
 [&lt;table&gt;...]
 : List of database tables to restrict the replacement to. Wildcards are
-supported, e.g. 'wp_*_options' or 'wp_post*'.
+supported, e.g. `'wp_*_options'` or `'wp_post*'`.
 
 [\--dry-run]
 : Run the entire search/replace operation and show report, but don't save


### PR DESCRIPTION
Otherwise, the `*` is markdownified.

See https://github.com/wp-cli/wp-cli/pull/2530