### PR TITLE
Publish `wp package` command docs

### DIFF
--- a/commands/package/browse/index.md
+++ b/commands/package/browse/index.md
@@ -1,0 +1,19 @@
+---
+layout: default
+title: 'wp package browse'
+display_global_parameters: true
+---
+
+`wp package browse` - Browse WP-CLI packages available for installation.
+
+<hr />
+
+Lists packages available for installation from the [Package Index](http://wp-cli.org/package-index/).
+
+### OPTIONS
+
+[\--format=&lt;format&gt;]
+: Accepted values: table, json, csv, yaml, ids. Default: table.
+
+
+

--- a/commands/package/index.md
+++ b/commands/package/index.md
@@ -1,0 +1,42 @@
+---
+layout: default
+title: 'wp package'
+display_global_parameters: true
+---
+
+`wp package` - Manage WP-CLI packages.
+
+<hr />
+
+
+
+
+
+### SUBCOMMANDS
+
+<table>
+	<thead>
+	<tr>
+		<th>Name</th>
+		<th>Description</th>
+	</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td><a href="/commands/package/browse/">browse</a></td>
+			<td>Browse WP-CLI packages available for installation.</td>
+		</tr>
+		<tr>
+			<td><a href="/commands/package/install/">install</a></td>
+			<td>Install a WP-CLI package.</td>
+		</tr>
+		<tr>
+			<td><a href="/commands/package/list/">list</a></td>
+			<td>List installed WP-CLI packages.</td>
+		</tr>
+		<tr>
+			<td><a href="/commands/package/uninstall/">uninstall</a></td>
+			<td>Uninstall a WP-CLI package.</td>
+		</tr>
+	</tbody>
+</table>

--- a/commands/package/install/index.md
+++ b/commands/package/install/index.md
@@ -1,0 +1,25 @@
+---
+layout: default
+title: 'wp package install'
+display_global_parameters: true
+---
+
+`wp package install` - Install a WP-CLI package.
+
+<hr />
+
+### OPTIONS
+
+&lt;name&gt;
+: Name of the package to install. Can optionally contain a version constraint.
+
+### EXAMPLES
+
+    # install the latest development version
+    wp package install wp-cli/server-command
+
+    # install the latest stable version
+    wp package install wp-cli/server-command:@stable
+
+
+

--- a/commands/package/list/index.md
+++ b/commands/package/list/index.md
@@ -1,0 +1,17 @@
+---
+layout: default
+title: 'wp package list'
+display_global_parameters: true
+---
+
+`wp package list` - List installed WP-CLI packages.
+
+<hr />
+
+### OPTIONS
+
+[\--format=&lt;format&gt;]
+: Accepted values: table, json, csv, yaml, ids. Default: table
+
+
+

--- a/commands/package/uninstall/index.md
+++ b/commands/package/uninstall/index.md
@@ -1,0 +1,17 @@
+---
+layout: default
+title: 'wp package uninstall'
+display_global_parameters: true
+---
+
+`wp package uninstall` - Uninstall a WP-CLI package.
+
+<hr />
+
+### OPTIONS
+
+&lt;name&gt;
+: Name of the package to uninstall.
+
+
+


### PR DESCRIPTION
But don't link them up yet. We just want them as direct reference.

See https://github.com/wp-cli/wp-cli/issues/1564