### PR TITLE
Inject `/config/` and `/commands/` into docs list by default

### DIFF
--- a/Phakefile.php
+++ b/Phakefile.php
@@ -213,7 +213,18 @@ desc( 'Update the /docs/ page.' );
 task( 'doc-list', function( $app ){
 	$docs = array(
 		'Guides'       => array(),
-		'References'   => array(),
+		'References'   => array(
+			'Configuration options' => array(
+				'path'        => '/config/',
+				'title'       => 'Configuration options defining how a command is executed.',
+				'description' => '',
+			),
+			'Built-in commands' => array(
+				'path'        => '/commands/',
+				'title'       => 'Built-in commands',
+				'description' => 'Commands included in every copy of WP-CLI.',
+			),
+		),
 		'Contributing' => array(),
 		'Misc'         => array(),
 	);
@@ -232,7 +243,7 @@ task( 'doc-list', function( $app ){
 		preg_match( '#description:\s(.+)#', $header, $matches );
 		$description = ! empty( $matches[1] ) ? $matches[1] : '';
 		$docs[ $category ][ $title ] = array(
-			'path'        => basename( dirname( $file ) ),
+			'path'        => '/docs/' . basename( dirname( $file ) ) . '/',
 			'title'       => $title,
 			'description' => $description,
 		);
@@ -246,7 +257,7 @@ task( 'doc-list', function( $app ){
 		$out .= '<ul>' . PHP_EOL;
 		ksort( $cat_docs );
 		foreach( $cat_docs as $cat_doc ) {
-			$out .= '<li><a href="/docs/' . $cat_doc['path'] . '/"><strong>' . $cat_doc['title'] . '</strong></a>';
+			$out .= '<li><a href="' . $cat_doc['path'] . '"><strong>' . $cat_doc['title'] . '</strong></a>';
 			if ( ! empty( $cat_doc['description'] ) ) {
 				$out .= ' - ' . $cat_doc['description'];
 			}

--- a/_includes/doc-list.html
+++ b/_includes/doc-list.html
@@ -9,6 +9,8 @@
 <h3>References</h3>
 
 <ul>
+<li><a href="/commands/"><strong>Built-in commands</strong></a> - Commands included in every copy of WP-CLI.</li>
+<li><a href="/config/"><strong>Configuration options defining how a command is executed.</strong></a></li>
 <li><a href="/docs/hosting-companies/"><strong>Hosting Companies</strong></a> - List of hosting companies with WP-CLI installed by default.</li>
 <li><a href="/docs/tools/"><strong>Integrated Tools</strong></a> - External projects that integrate with WP-CLI in some form.</li>
 <li><a href="/docs/internal-api/"><strong>Internal API</strong></a> - Stable utilities considered safe to use in community commands.</li>


### PR DESCRIPTION
See https://github.com/wp-cli/wp-cli/issues/2508