### PR TITLE
Mark `WP_CLI::run_command()` as a public API

### DIFF
--- a/_includes/internal-api-list.html
+++ b/_includes/internal-api-list.html
@@ -80,6 +80,9 @@
 <li><strong><a href="/docs/internal-api/wp-cli-launch-self/">WP_CLI::launch_self()</a></strong> - Run a WP-CLI command in a new process reusing the current runtime arguments.</li>
 
 
+<li><strong><a href="/docs/internal-api/wp-cli-run-command/">WP_CLI::run_command()</a></strong> - Run a given command within the current process using the same global</li>
+
+
 </ul>
 
 

--- a/docs/internal-api/wp-cli-launch-self/index.md
+++ b/docs/internal-api/wp-cli-launch-self/index.md
@@ -27,6 +27,16 @@ Run a WP-CLI command in a new process reusing the current runtime arguments.
 </div>
 
 
+***
+
+### Notes
+
+Note: While this command does persist a limited set of runtime arguments,
+it *does not* persist environment variables. Practically speaking, WP-CLI
+packages won't be loaded when using WP_CLI::launch_self() because the
+launched process doesn't have access to the current process $HOME.
+
+
 *Internal API documentation is generated from the WP-CLI codebase on every release. To suggest improvements, please submit a pull request.*
 
 
@@ -39,6 +49,9 @@ Run a WP-CLI command in a new process reusing the current runtime arguments.
 
 
 <li><strong><a href="/docs/internal-api/wp-cli-launch/">WP_CLI::launch()</a></strong> - Launch an arbitrary external process that takes over I/O.</li>
+
+
+<li><strong><a href="/docs/internal-api/wp-cli-run-command/">WP_CLI::run_command()</a></strong> - Run a given command within the current process using the same global</li>
 
 
 

--- a/docs/internal-api/wp-cli-launch/index.md
+++ b/docs/internal-api/wp-cli-launch/index.md
@@ -52,6 +52,9 @@ Launch an arbitrary external process that takes over I/O.
 <li><strong><a href="/docs/internal-api/wp-cli-launch-self/">WP_CLI::launch_self()</a></strong> - Run a WP-CLI command in a new process reusing the current runtime arguments.</li>
 
 
+<li><strong><a href="/docs/internal-api/wp-cli-run-command/">WP_CLI::run_command()</a></strong> - Run a given command within the current process using the same global</li>
+
+
 
 </ul>
 

--- a/docs/internal-api/wp-cli-run-command/index.md
+++ b/docs/internal-api/wp-cli-run-command/index.md
@@ -1,0 +1,62 @@
+---
+layout: default
+title: WP_CLI::run_command()
+description: Run a given command within the current process using the same global
+---
+
+<a href="/docs/">Docs</a> &raquo; <a href="/docs/internal-api/">Internal API</a> &raquo; Execution
+
+## WP_CLI::run_command()
+
+Run a given command within the current process using the same global
+
+***
+
+### Usage
+
+    WP_CLI::run_command( $args, $assoc_args = array() )
+
+<div>
+<strong>$args</strong> (array) Positional arguments including command name.<br />
+<strong>$assoc_args</strong> (array) <br />
+</div>
+
+
+***
+
+### Notes
+
+parameters.
+
+To run a command using a new process with the same global parameters,
+use WP_CLI::launch_self(). To run a command using a new process with
+different global parameters, use WP_CLI::launch().
+
+
+    ob_start();
+    WP_CLI::run_command( array( 'cli', 'cmd-dump' ) );
+    $ret = ob_get_clean();
+    
+
+
+*Internal API documentation is generated from the WP-CLI codebase on every release. To suggest improvements, please submit a pull request.*
+
+
+***
+
+### Related
+
+<ul>
+
+
+
+<li><strong><a href="/docs/internal-api/wp-cli-launch/">WP_CLI::launch()</a></strong> - Launch an arbitrary external process that takes over I/O.</li>
+
+
+<li><strong><a href="/docs/internal-api/wp-cli-launch-self/">WP_CLI::launch_self()</a></strong> - Run a WP-CLI command in a new process reusing the current runtime arguments.</li>
+
+
+
+</ul>
+
+


### PR DESCRIPTION
See https://github.com/wp-cli/wp-cli/pull/2586