### PR TITLE
Fix return signature generation

### DIFF
--- a/command.php
+++ b/command.php
@@ -54,25 +54,18 @@ function get_simple_representation( $reflection ) {
 		$parameter_signature = '$' . $parameter->getName();
 		if ( $parameter->isOptional() ) {
 			$default_value = $parameter->getDefaultValue();
-			switch ( $default_value ) {
-				case array():
-					$parameter_signature .= ' = array()';
-					break;
-				case '':
-					$parameter_signature .= " = ''";
-					break;
-				case null:
-					$parameter_signature .= ' = null';
-					break;
-				case true:
-					$parameter_signature .= ' = true';
-					break;
-				case false:
-					$parameter_signature .= ' = false';
-					break;
-				default:
-					$parameter_signature .= ' = ' . $default_value;
-					break;
+			if ( false === $default_value ) {
+				$parameter_signature .= ' = false';
+			} else if ( array() === $default_value ) {
+				$parameter_signature .= ' = array()';
+			} else if ( '' === $default_value ) {
+				$parameter_signature .= " = ''";
+			} else if ( null === $default_value ) {
+				$parameter_signature .= ' = null';
+			} else if ( true === $default_value ) {
+				$parameter_signature .= ' = true';
+			} else {
+				$parameter_signature .= ' = ' . $default_value;
 			}
 		}
 		$parameters[] = $parameter_signature;

--- a/docs/internal-api/wp-cli-launch-self/index.md
+++ b/docs/internal-api/wp-cli-launch-self/index.md
@@ -14,7 +14,7 @@ Run a WP-CLI command in a new process reusing the current runtime arguments.
 
 ### Usage
 
-    WP_CLI::launch_self( $command, $args = array(), $assoc_args = array(), $exit_on_error = true, $return_detailed = array(), $runtime_args = array() )
+    WP_CLI::launch_self( $command, $args = array(), $assoc_args = array(), $exit_on_error = true, $return_detailed = false, $runtime_args = array() )
 
 <div>
 <strong>$command</strong> (string) WP-CLI command to call.<br />

--- a/docs/internal-api/wp-cli-launch/index.md
+++ b/docs/internal-api/wp-cli-launch/index.md
@@ -14,7 +14,7 @@ Launch an arbitrary external process that takes over I/O.
 
 ### Usage
 
-    WP_CLI::launch( $command, $exit_on_error = true, $return_detailed = array() )
+    WP_CLI::launch( $command, $exit_on_error = true, $return_detailed = false )
 
 <div>
 <strong>$command</strong> (string) External process to launch.<br />

--- a/docs/internal-api/wp-cli-utils-get-flag-value/index.md
+++ b/docs/internal-api/wp-cli-utils-get-flag-value/index.md
@@ -14,7 +14,7 @@ Return the flag value or, if it's not set, the $default value.
 
 ### Usage
 
-    WP_CLI\Utils\get_flag_value( $assoc_args, $flag, $default = array() )
+    WP_CLI\Utils\get_flag_value( $assoc_args, $flag, $default = null )
 
 <div>
 <strong>$assoc_args</strong> (array) Arguments array.<br />

--- a/docs/internal-api/wp-cli-utils-http-request/index.md
+++ b/docs/internal-api/wp-cli-utils-http-request/index.md
@@ -14,7 +14,7 @@ Make a HTTP request to a remote URL.
 
 ### Usage
 
-    WP_CLI\Utils\http_request( $method, $url, $data = array(), $headers = array(), $options = array() )
+    WP_CLI\Utils\http_request( $method, $url, $data = null, $headers = array(), $options = array() )
 
 <div>
 <strong>$method</strong> (string) HTTP method (GET, POST, DELETE, etc.)<br />


### PR DESCRIPTION
As it turns out, `switch()` doesn't do strict type comparison

Fixes #133