### PR TITLE
Increase minimum supported version to PHP 5.3.29

### DIFF
--- a/index.md
+++ b/index.md
@@ -18,7 +18,7 @@ title: Command line interface for WordPress
 <h2 id="requirements">Requirements</h2>
 
 * UNIX-like environment (OS X, Linux, FreeBSD, Cygwin); limited support in Windows environment
-* PHP 5.3.2 or later
+* PHP 5.3.29 or later
 * WordPress 3.7 or later
 
 <h2 id="install">Installing (And Upgrading)</h2>


### PR DESCRIPTION
While WP-CLI may work with earlier versions, this is the minimum version
we can support because 5.3.29 is the version available in Travis.

See https://github.com/wp-cli/wp-cli/issues/2669