### PR TITLE
Update Installing on Windows section

### DIFF
--- a/docs/installing/index.md
+++ b/docs/installing/index.md
@@ -152,6 +152,8 @@ Add `c:\wp-cli` to your path:
 
     setx path "%path%;c:\wp-cli"
 
+Rename `wp-cli.phar` to `wp` 
+
 You can now use WP-CLI from anywhere in Windows command line.
 
 ### Installing via .deb package


### PR DESCRIPTION
Windows users need to rename "wp-cli.phar" to "wp" in order to be able to type "wp" in a terminal.