### PR TITLE
Document behavior of `wp core install` with WP in a subdirectory

### DIFF
--- a/commands/core/install/index.md
+++ b/commands/core/install/index.md
@@ -4,11 +4,21 @@ title: 'wp core install'
 display_global_parameters: true
 ---
 
-`wp core install` - Create the WordPress tables in the database.
+`wp core install` - Runs the standard WordPress installation process.
 
 <small>Quick links: <a href="https://github.com/wp-cli/wp-cli/issues?q=is%3Aopen+label%3Acommand%3Acore-install+sort%3Aupdated-desc">Github issues</a></small>
 
 <hr />
+
+Creates the WordPress tables in the database using the URL, title, and
+default admin user details provided. Performs the famous 5 minute install
+in seconds or less.
+
+Note: if you've installed WordPress in a subdirectory, then you'll need
+to `wp option update siteurl` after `wp core install`. For instance, if
+WordPress is installed in the `/wp` directory and your domain is wp.dev,
+then you'll need to run `wp option update siteurl http://wp.dev/wp` for
+your WordPress install to function properly.
 
 ### OPTIONS
 


### PR DESCRIPTION
From https://github.com/wp-cli/wp-cli/pull/2707