### PR TITLE
Update index.md following ja translation rules

### DIFF
--- a/ja/index.md
+++ b/ja/index.md
@@ -3,10 +3,10 @@ layout: default
 title: Command line interface for WordPress
 ---
 
-[WP-CLI](https://wp-cli.org/)は[WordPress](https://wordpress.org/)を管理するためのコマンドラインツールです。
+[WP-CLI](https://wp-cli.org/) は [WordPress](https://wordpress.org/) を管理するためのコマンドラインツールです。
 プラグインのアップデートやマルチサイトのセットアップなどの多くのことをブラウザ無しで行うことができます。
 
-最新情報を得たい人は、[@wpcli on Twitter](https://twitter.com/wpcli)をフォローするか、[メーリングリストにサインアップ](http://wp-cli.us13.list-manage.com/subscribe?u=0615e4d18f213891fc000adfd&id=8c61d7641e)してください。
+最新情報を得たい人は、[@wpcli on Twitter](https://twitter.com/wpcli) をフォローするか、[メーリングリストにサインアップ](http://wp-cli.us13.list-manage.com/subscribe?u=0615e4d18f213891fc000adfd&id=8c61d7641e)してください。
 
 [![Build Status](https://travis-ci.org/wp-cli/wp-cli.png?branch=master)](https://travis-ci.org/wp-cli/wp-cli) [![Dependency Status](https://gemnasium.com/badges/github.com/wp-cli/wp-cli.svg)](https://gemnasium.com/github.com/wp-cli/wp-cli) [![Average time to resolve an issue](http://isitmaintained.com/badge/resolution/wp-cli/wp-cli.svg)](http://isitmaintained.com/project/wp-cli/wp-cli "Average time to resolve an issue") [![Percentage of issues still open](http://isitmaintained.com/badge/open/wp-cli/wp-cli.svg)](http://isitmaintained.com/project/wp-cli/wp-cli "Percentage of issues still open")
 
@@ -18,14 +18,14 @@ title: Command line interface for WordPress
 	padding-left: 10px;
 	padding-right: 10px;
 ">
-	<p><strong>A more RESTful WP-CLI</strong>は、コマンドラインによってWP REST APIのポテンシャルを解放します。このプロジェクトはPressed、Chris Lema、Human Made、Pagely、Pantheon、その他大勢の人たちによって支援されています。<a href="https://wp-cli.org/restful/">さらに詳しく &rarr;</a></p>
+	<p><strong>A more RESTful WP-CLI</strong> は、コマンドラインによって WP REST API のポテンシャルを解放します。このプロジェクトは Pressed、Chris Lema、Human Made、Pagely、Pantheon、その他大勢の人たちによって支援されています。<a href="https://wp-cli.org/restful/">さらに詳しく &rarr;</a></p>
 </div>
 
 Quick links: [使い方](#section) &#124; [インストール方法](#section-1) &#124; [サポート](#section-2) &#124; [拡張](#section-3) &#124; [貢献](#section-4) &#124; [クレジット](#section-5)
 
 ## 使い方
 
-WP-CLIのゴールは、みなさんがWordPressの管理画面でやりたいと思うことをコマンドラインで提供することです。
+WP-CLI のゴールは、みなさんが WordPress の管理画面でやりたいと思うことをコマンドラインで提供することです。
 たとえば、`wp plugin install --activate` ([ドキュメント](https://wp-cli.org/commands/plugin/install/)) は、プラグインをインストールし有効化します。
 
 ```
@@ -39,28 +39,28 @@ Activating 'rest-api'...
 Success: Plugin 'rest-api' activated.
 ```
 
-さらにWP-CLIは、WordPressの管理画面ではできない多くのことが可能です。たとえば、`wp transient delete-all` ([doc](https://wp-cli.org/commands/transient/delete-all/)) は、Transientに保存されているすべてのデータを削除することを可能にしています。
+さらに WP-CLI は、WordPress の管理画面ではできない多くのことが可能です。たとえば、`wp transient delete-all` ([doc](https://wp-cli.org/commands/transient/delete-all/)) は、Transient に保存されているすべてのデータを削除することを可能にしています。
 
 ```
 $ wp transient delete-all
 Success: 34 transients deleted from the database.
 ```
 
-WP-CLIの使い方に関するさらに詳しい情報は、[クイックスタートガイド](https://wp-cli.org/docs/quick-start/)を読んでください。
+WP-CLI の使い方に関するさらに詳しい情報は、[クイックスタートガイド](https://wp-cli.org/docs/quick-start/)を読んでください。
 
 もし、すでに基本的なことを理解しているなら、[コマンドリスト](https://wp-cli.org/ja/commands/)にジャンプして、テーマやプラグインの管理、データのインポートやエクスポート、データベースの操作などについての詳細をみてください。
 
 ## インストール方法
 
-Pharファイルをダウンロードする方法が、私たちが推奨するインストール方法です。必要なら[上級者向けインストール方法](https://wp-cli.org/docs/installing/)(英語)を見てください。
+Phar ファイルをダウンロードする方法が、私たちが推奨するインストール方法です。必要なら[上級者向けインストール方法](https://wp-cli.org/docs/installing/)(英語)を見てください。
 
-WP-CLIをインストールする前に、動作環境を確認してください。
+WP-CLI をインストールする前に、動作環境を確認してください。
 
-- UNIX系の環境 (OS X, Linux, FreeBSD, Cygwin); Windowsでは一部の機能に制限があります。
+- UNIX 系の環境 (OS X, Linux, FreeBSD, Cygwin); Windows では一部の機能に制限があります。
 - PHP 5.3.29 またはそれ以降のバージョン
 - WordPress 3.7 またはそれ以降のバージョン
 
-動作条件を再度確認してから、`wget`または`curl`を使用して[wp-cli.phar](https://raw.github.com/wp-cli/builds/gh-pages/phar/wp-cli.phar)をダウンロードしてください。
+動作条件を再度確認してから、`wget`または`curl`を使用して [wp-cli.phar](https://raw.github.com/wp-cli/builds/gh-pages/phar/wp-cli.phar) をダウンロードしてください。
 
 ```
 $ curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
@@ -72,14 +72,14 @@ $ curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.p
 $ php wp-cli.phar --info
 ```
 
-WP-CLIコマンドを`wp`で実行するには、それに実行権限があることと環境変数`PATH`に登録されていることが必要です。
+WP-CLI コマンドを`wp`で実行するには、それに実行権限があることと環境変数`PATH`に登録されていることが必要です。
 
 ```
 $ chmod +x wp-cli.phar
 $ sudo mv wp-cli.phar /usr/local/bin/wp
 ```
 
-もし、WP-CLIのインストールが成功していれば、`wp --info`を実行したら以下のように出力されるはずです。
+もし、WP-CLI のインストールが成功していれば、`wp --info`を実行したら以下のように出力されるはずです。
 
 ```
 $ wp --info
@@ -93,11 +93,11 @@ WP-CLI project config:
 WP-CLI version: 0.23.0
 ```
 
-WP-CLIをアップデートするには、`wp cli update` ([doc](https://wp-cli.org/commands/cli/update/)) を実行するか、上述のインストール方法を再度行う必要があります。
+WP-CLI をアップデートするには、`wp cli update` ([doc](https://wp-cli.org/commands/cli/update/)) を実行するか、上述のインストール方法を再度行う必要があります。
 
 ## サポート
 
-WP-CLIのメンテナーとプロジェクトの貢献者たちは、新しいIssueに対して、より迅速に返信したいと思っています。これらのボランティアの時間を節約するために、過去に同じ質問に対する回答がないかを確認してください。
+WP-CLI のメンテナーとプロジェクトの貢献者たちは、新しい Issue に対して、より迅速に返信したいと思っています。これらのボランティアの時間を節約するために、過去に同じ質問に対する回答がないかを確認してください。
 
 - [Common issues and their fixes](https://wp-cli.org/docs/common-issues/)
 - [Best practices for submitting a bug report](https://wp-cli.org/docs/bug-reports/)
@@ -105,17 +105,17 @@ WP-CLIのメンテナーとプロジェクトの貢献者たちは、新しいIs
 - [Open or closed issues on Github](https://github.com/wp-cli/wp-cli/issues?utf8=%E2%9C%93&q=is%3Aissue)
 - [WordPress StackExchange forums](http://wordpress.stackexchange.com/questions/tagged/wp-cli)
 
-もしあなたがWordPress.orgのアカウントを持っているなら、[WordPress.org Slack organization](https://make.wordpress.org/chat/)の`#cli`チャンネルに参加することもできます。
+もしあなたが WordPress.org のアカウントを持っているなら、[WordPress.org Slack organization](https://make.wordpress.org/chat/) の`#cli`チャンネルに参加することもできます。
 
 ## Extending
 
-それぞれの **コマンド** は、WP-CLIの関数の一つとして定義されています。`wp plugin install` ([doc](https://wp-cli.org/commands/plugin/install/)) はそのうちのひとつであり、`wp plugin activate` ([doc](https://wp-cli.org/commands/plugin/activate/)) は別のもうひとつです。
+それぞれの **コマンド** は、WP-CLI の関数の一つとして定義されています。`wp plugin install` ([doc](https://wp-cli.org/commands/plugin/install/)) はそのうちのひとつであり、`wp plugin activate` ([doc](https://wp-cli.org/commands/plugin/activate/)) は別のもうひとつです。
 
-WP-CLIは、多くのコマンドにより構成されており、カスタムコマンドを作ることは意外と簡単です。[commands cookbook](https://wp-cli.org/docs/commands-cookbook/)を読んでください。
+WP-CLI は、多くのコマンドにより構成されており、カスタムコマンドを作ることは意外と簡単です。[commands cookbook](https://wp-cli.org/docs/commands-cookbook/)を読んでください。
 
 ## 貢献
 
-開発に参加するには、まずはじめに[creating an issue](https://wp-cli.org/docs/bug-reports/) or [submitting a pull request](https://wp-cli.org/docs/pull-requests/)を読んでください。
+開発に参加するには、まずはじめに [creating an issue](https://wp-cli.org/docs/bug-reports/) or [submitting a pull request](https://wp-cli.org/docs/pull-requests/) を読んでください。
 
 ### プロジェクトリーダー
 
@@ -127,7 +127,7 @@ WP-CLIは、多くのコマンドにより構成されており、カスタム�
 
 ## クレジット
 
-[composer.json](composer.json)に記載されているライブラリに依存しており、以下のプロジェクトからコードやアイディアを得ています。
+[composer.json](composer.json) に記載されているライブラリに依存しており、以下のプロジェクトからコードやアイディアを得ています。
 
 * [Drush](http://drush.ws/) for... a lot of things
 * [wpshell](http://code.trac.wordpress.org/browser/wpshell) for `wp shell`


### PR DESCRIPTION
Ive updated index.md to follow WordPress Japanese translation guidelines*, in order to do better visibility of websites for Japanese users.
Mainly added to put into spaces before or after English word.

*see below;
http://wpdocs.osdn.jp/WordPress_%E3%81%AE%E7%BF%BB%E8%A8%B3/%E7%BF%BB%E8%A8%B3%E3%82%AC%E3%82%A4%E3%83%89%E3%83%A9%E3%82%A4%E3%83%B3

No change on Japanese expression out of respect to rock star of Kushimoto.