### PR TITLE
Added xargs example for creating post and adding post meta

### DIFF
--- a/docs/shell-tips/index.md
+++ b/docs/shell-tips/index.md
@@ -70,3 +70,11 @@ Explanation
 - List all post ID-s
 - Get each content (xargs)
 - Display only image URL-s (sed)
+
+## Create a page from a file and flag it with the file name
+
+```bash
+wp post create new_page.html --post_type=page --post_title="New Page" --porcelain | xargs -I % wp post meta add % imported_from new_page.html
+```
+- Create a page (--porcelain will return only the new post ID)
+- Create post meta with xargs using "-I %" to signify the placeholder template for the new post ID


### PR DESCRIPTION
I had to document something similar to this for a client today.  Since I don't do shell scripts very often, it wasn't obvious how to pass the new post ID to the post meta command via xargs, but figured it out after some Googling, so this example might be useful.

If this sort of example would be handy directly via `wp help post create`, I can add it to the other repo.