### PR TITLE
Remove erroneous `## OPTIONS` from comment meta

### DIFF
--- a/commands/comment/meta/index.md
+++ b/commands/comment/meta/index.md
@@ -10,11 +10,6 @@ display_global_parameters: true
 
 <hr />
 
-### OPTIONS
-
-\--format=json
-: Encode/decode values as JSON.
-
 ### EXAMPLES
 
     # Set comment meta


### PR DESCRIPTION
See https://github.com/wp-cli/wp-cli/pull/3338