### PR TITLE
Update examples of `wp foo` instances

### DIFF
--- a/docs/commands-cookbook/index.md
+++ b/docs/commands-cookbook/index.md
@@ -77,6 +77,19 @@ class Foo_Command {
     }
 }
 WP_CLI::add_command( 'foo', 'Foo_Command' );
+
+// 4. Command is a method on a class with constructor arguments
+class Foo_Command {
+    protected $bar;
+    public function __construct( $bar ) {
+        $this->bar = $bar;
+    }
+    public function __invoke( $args ) {
+        WP_CLI::success( $this->bar . ':' . $args[0] );
+    }
+}
+$instance = new Foo_Command( 'Some text' );
+WP_CLI::add_command( 'foo', $instance );
 ```
 
 Importantly, classes behave a bit differently than functions and closures in that:


### PR DESCRIPTION
Adds an example of creating a command using an instance of a class that has constructor arguments