### PR TITLE
Update hosting companies with WP-CLI support

### DIFF
--- a/docs/hosting-companies/index.md
+++ b/docs/hosting-companies/index.md
@@ -26,6 +26,7 @@ In alphabetical order:
 * [Monarobase](https://monarobase.net/wordpress)
 * [NearlyFreeSpeech.NET](https://www.nearlyfreespeech.net/)
 * [Pantheon](https://pantheon.io)
+* [Pressjitsu](https://pressjitsu.com)
 * [RoseHosting](https://www.rosehosting.com)
 * [Seravo.com](https://seravo.com)
 * [Site5](http://www.site5.com/)


### PR DESCRIPTION
Add Pressjitsu to the list of hosting companies that come with WP-CLI pre-installed. Because we do :)