### PR TITLE
Clarify `wp cli update` when WP-CLI is owned by root

### DIFF
--- a/docs/installing/index.md
+++ b/docs/installing/index.md
@@ -51,7 +51,7 @@ Wondering what to do next? Check out the [quick start guide](/docs/quick-start/)
 
 ### Updating WP-CLI
 
-If you have installed WP-CLI using the recommended Phar method, you can update it at any time by running `wp cli update`. If you installed WP-CLI using the Git or Composer-based installations, see the specific instructions for updating associated with each method below.  
+If you have installed WP-CLI using the recommended Phar method, you can update it at any time by running `wp cli update` (although if WP-CLI is owned by root, that may be `sudo wp cli update`). If you installed WP-CLI using the Git or Composer-based installations, see the specific instructions for updating associated with each method below.  
 
 When you run `wp cli update`, you'll be prompted to confirm that you wish to update with a message similar to the following:
 

--- a/index.md
+++ b/index.md
@@ -84,6 +84,8 @@ WP-CLI version: 0.25.0
 
 You can update WP-CLI with `wp cli update` ([doc](https://wp-cli.org/commands/cli/update/)), or by repeating the installation steps.
 
+If WP-CLI is owned by root or another system user, you'll need to run `sudo wp cli update`.
+
 Want to live life on the edge? Run `wp cli update --nightly` to use the latest nightly build of WP-CLI. The nightly build is more or less stable enough for you to use in your development environment, and always includes the latest and greatest WP-CLI features.
 
 ### Tab completions


### PR DESCRIPTION
Fixes https://github.com/wp-cli/wp-cli/issues/3572