### PR TITLE
Change example Composer configuration in index.md

### DIFF
--- a/docs/installing/index.md
+++ b/docs/installing/index.md
@@ -127,7 +127,7 @@ Above script assumes that your current shell is `bash`, which might not be the c
 In case you got `bash` available and installed for your OS, you can switch dynamically:
 
     "scripts" : {
-    	"post-install-cmd" : [
+    	"post-update-cmd" : [
     		"/bin/bash -c \"[[ -f /usr/local/bin/wp ]] || sudo ln -s /var/www/vendor/wp-cli/wp-cli/bin/wp /usr/bin/wp\"",
     		"/bin/bash -c \"source /var/www/vendor/wp-cli/wp-cli/utils/wp-completion.bash\"",
         "/bin/bash -c \"[[ -f ~/.bash_profile ]] || touch ~/.bash_profile\"",


### PR DESCRIPTION
Change Composer example to use post-update-cmd instead of post-install-cmd. On first run post-install-cmd won't be executed. See https://getcomposer.org/doc/articles/scripts.md