### PR TITLE
Fix PHP arrows in generated documentation.

### DIFF
--- a/command.php
+++ b/command.php
@@ -513,6 +513,8 @@ function gen_cmd_pages( $cmd, $parent = array() ) {
 		$docs = preg_replace( '/ &gt; /', ' > ', $docs );
 		$docs = preg_replace( '/ &lt;&lt;/', ' <<', $docs );
 		$docs = preg_replace( '/&quot;/', '"', $docs );
+		$docs = preg_replace( '/wp&gt; /', 'wp> ', $docs );
+		$docs = preg_replace( '/=&gt;/', '=>', $docs );
 
 		// Strip global parameters -> added in footer
 		$docs = preg_replace( '/#?## GLOBAL PARAMETERS.+/s', '', $docs );

--- a/commands/cli/param-dump/index.md
+++ b/commands/cli/param-dump/index.md
@@ -31,16 +31,16 @@ options:
     # Dump the list of global parameters.
     $ wp cli param-dump --format=var_export
     array (
-      'path' =&gt;
+      'path' =>
       array (
-        'runtime' =&gt; '=&lt;path&gt;',
-        'file' =&gt; '&lt;path&gt;',
-        'synopsis' =&gt; '',
-        'default' =&gt; NULL,
-        'multiple' =&gt; false,
-        'desc' =&gt; 'Path to the WordPress files.',
+        'runtime' => '=&lt;path&gt;',
+        'file' => '&lt;path&gt;',
+        'synopsis' => '',
+        'default' => NULL,
+        'multiple' => false,
+        'desc' => 'Path to the WordPress files.',
       ),
-      'url' =&gt;
+      'url' =>
       array (
 
 

--- a/commands/network/meta/index.md
+++ b/commands/network/meta/index.md
@@ -17,7 +17,7 @@ display_global_parameters: true
     # Get a list of super-admins
     $ wp network meta get 1 site_admins
     array (
-      0 =&gt; 'supervisor',
+      0 => 'supervisor',
     )
 
 

--- a/commands/shell/index.md
+++ b/commands/shell/index.md
@@ -27,8 +27,8 @@ that you can use within a WordPress plugin, for example.
 
     # Call get_bloginfo() to get the name of the site.
     $ wp shell
-    wp&gt; get_bloginfo( 'name' );
-    =&gt; string(6) "WP-CLI"
+    wp> get_bloginfo( 'name' );
+    => string(6) "WP-CLI"
 
 
 


### PR DESCRIPTION
Some example code in the generated docs contains the PHP arrow (`=>`), which is HTML-encoded and thus corrupted in code snippets.
This fixes the generation for these instances.