### PR TITLE
Corrected command examples concerning the "Hello Dolly" plugin

### DIFF
--- a/commands/plugin/activate/index.md
+++ b/commands/plugin/activate/index.md
@@ -26,13 +26,13 @@ display_global_parameters: true
 ### EXAMPLES
 
     # Activate plugin
-    $ wp plugin activate hello-dolly
-    Plugin 'hello-dolly' activated.
+    $ wp plugin activate hello
+    Plugin 'hello' activated.
     Success: Activated 1 of 1 plugins.
 
     # Activate plugin in entire multisite network
-    $ wp plugin activate hello-dolly --network
-    Plugin 'hello-dolly' network activated.
+    $ wp plugin activate hello --network
+    Plugin 'hello' network activated.
     Success: Network activated 1 of 1 plugins.
 
 

--- a/commands/plugin/deactivate/index.md
+++ b/commands/plugin/deactivate/index.md
@@ -29,8 +29,8 @@ display_global_parameters: true
 ### EXAMPLES
 
     # Deactivate plugin
-    $ wp plugin deactivate hello-dolly
-    Plugin 'hello-dolly' deactivated.
+    $ wp plugin deactivate hello
+    Plugin 'hello' deactivated.
     Success: Deactivated 1 of 1 plugins.
 
 

--- a/commands/plugin/index.md
+++ b/commands/plugin/index.md
@@ -15,18 +15,18 @@ display_global_parameters: true
 ### EXAMPLES
 
     # Activate plugin
-    $ wp plugin activate hello-dolly
-    Plugin 'hello-dolly' activated.
+    $ wp plugin activate hello
+    Plugin 'hello' activated.
     Success: Activated 1 of 1 plugins.
 
     # Deactivate plugin
-    $ wp plugin deactivate hello-dolly
-    Plugin 'hello-dolly' deactivated.
+    $ wp plugin deactivate hello
+    Plugin 'hello' deactivated.
     Success: Deactivated 1 of 1 plugins.
 
     # Delete plugin
-    $ wp plugin delete hello-dolly
-    Deleted 'hello-dolly' plugin.
+    $ wp plugin delete hello
+    Deleted 'hello' plugin.
     Success: Deleted 1 of 1 plugins.
 
     # Install the latest version from wordpress.org and activate

--- a/commands/plugin/is-installed/index.md
+++ b/commands/plugin/is-installed/index.md
@@ -22,7 +22,7 @@ Returns exit code 0 when installed, 1 when uninstalled.
 ### EXAMPLES
 
     # Check whether plugin is installed; exit status 0 if installed, otherwise 1
-    $ wp plugin is-installed hello-dolly
+    $ wp plugin is-installed hello
     $ echo $?
     1
 

--- a/commands/theme/is-installed/index.md
+++ b/commands/theme/is-installed/index.md
@@ -22,7 +22,7 @@ Returns exit code 0 when installed, 1 when uninstalled.
 ### EXAMPLES
 
     # Check whether theme is installed; exit status 0 if installed, otherwise 1
-    $ wp theme is-installed hello-dolly
+    $ wp theme is-installed hello
     $ echo $?
     1
 


### PR DESCRIPTION
The docs are using 'hello-dolly' which is invalid and will fail. Corrected plugin name to 'hello' which will work with the default Hello Dolly plugin as intended.