### PR TITLE
Changed http to https in all wp-cli links.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,7 +5,7 @@ markdown: kramdown
 gems:
   - jekyll-paginate
   - jekyll-redirect-from
-url: http://wp-cli.org
+url: https://wp-cli.org
 permalink: /blog/:title.html
 paginate: 10
 paginate_path: /blog/page:num

--- a/_posts/2013-10-04-version-0.12.md
+++ b/_posts/2013-10-04-version-0.12.md
@@ -33,7 +33,7 @@ This nifty little parameter changes the behaviour of commands when required argu
 
 ### Phar archives are back
 
-They were originally introduced in [version 0.9](http://wp-cli.org/blog/version-0.9.html) and... ahem, naively abandoned in the next release with the introduction of the installer script.
+They were originally introduced in [version 0.9](https://wp-cli.org/blog/version-0.9.html) and... ahem, naively abandoned in the next release with the introduction of the installer script.
 
 The installer uses Composer, which has its own environmental requirements, but, more importantly, it has to fetch all of the packages WP-CLI depends on, which is both less reliable and slower than downloading a single file that contains everything.
 

--- a/_posts/2014-04-29-survey-results.md
+++ b/_posts/2014-04-29-survey-results.md
@@ -16,20 +16,20 @@ Many thanks to the 56 people who took our first user survey. We appreciate your 
 
 Even with its variety of commands, WP-CLI is largely used to install and update. 37.5% of respondents reported using WP-CLI to install WordPress (with 30.36% using it to update WordPress), and 32.14% reported using it to update plugins and themes.
 
-After code management, WP-CLI is popularly used (23.21%) to perform migrations. Respondents reported using [`wp db export`](http://wp-cli.org/commands/db/export/) and [`wp db import`](http://wp-cli.org/commands/db/import/) in conjunction with [`wp search-replace`](http://wp-cli.org/commands/search-replace/), or [`wp export`](http://wp-cli.org/commands/export/) and [`wp import`](http://wp-cli.org/commands/import/).
+After code management, WP-CLI is popularly used (23.21%) to perform migrations. Respondents reported using [`wp db export`](https://wp-cli.org/commands/db/export/) and [`wp db import`](https://wp-cli.org/commands/db/import/) in conjunction with [`wp search-replace`](https://wp-cli.org/commands/search-replace/), or [`wp export`](https://wp-cli.org/commands/export/) and [`wp import`](https://wp-cli.org/commands/import/).
 
 A subset of respondents reported using WP-CLI to perform specialized tasks, including:
 
-* Creating users with [`wp user create`](http://wp-cli.org/commands/user/create/) and [`wp user import-csv`](http://wp-cli.org/commands/user/import-csv/).
-* [Deleting options](http://wp-cli.org/commands/option/delete/).
-* [Resizing images](http://wp-cli.org/commands/media/regenerate/).
-* [Creating posts / pages](http://wp-cli.org/commands/post/create/).
-* Quick code execution via [`wp eval`](http://wp-cli.org/commands/eval/), [`wp eval-file`](http://wp-cli.org/commands/eval-file/), and [`wp shell`](http://wp-cli.org/commands/shell/).
+* Creating users with [`wp user create`](https://wp-cli.org/commands/user/create/) and [`wp user import-csv`](https://wp-cli.org/commands/user/import-csv/).
+* [Deleting options](https://wp-cli.org/commands/option/delete/).
+* [Resizing images](https://wp-cli.org/commands/media/regenerate/).
+* [Creating posts / pages](https://wp-cli.org/commands/post/create/).
+* Quick code execution via [`wp eval`](https://wp-cli.org/commands/eval/), [`wp eval-file`](https://wp-cli.org/commands/eval-file/), and [`wp shell`](https://wp-cli.org/commands/shell/).
 * [Writing custom commands](https://github.com/wp-cli/wp-cli/wiki/Commands-Cookbook).
 
 **Only 38% have used community packages**
 
-WP-CLI now has 24 community packages listed in its [Package Index](http://wp-cli.org/package-index/). A good 62% percent of respondents will have the good fortune in the future to discover a helpful community package.
+WP-CLI now has 24 community packages listed in its [Package Index](https://wp-cli.org/package-index/). A good 62% percent of respondents will have the good fortune in the future to discover a helpful community package.
 
 ### Feature requests
 

--- a/_posts/2014-06-30-version-0.16.md
+++ b/_posts/2014-06-30-version-0.16.md
@@ -61,7 +61,7 @@ If any core files have been modified, you'll see something like this:
 
 ### A new look
 
-[WP-CLI.org](http://wp-cli.org) received a much-appreciated fresh coat of paint. [Share the love on Twitter](https://twitter.com/intent/tweet?text=Love%20the%20fresh%20coat%20of%20paint%2C%20%40wpcli%21%20Check%20it%20out%3A%20http%3A%2F%2Fwp-cli.org) (or report any bugs in the [issue tracker](https://github.com/wp-cli/wp-cli/issues/new)).
+[WP-CLI.org](https://wp-cli.org) received a much-appreciated fresh coat of paint. [Share the love on Twitter](https://twitter.com/intent/tweet?text=Love%20the%20fresh%20coat%20of%20paint%2C%20%40wpcli%21%20Check%20it%20out%3A%20http%3A%2F%2Fwp-cli.org) (or report any bugs in the [issue tracker](https://github.com/wp-cli/wp-cli/issues/new)).
 
 ### Other changes
 

--- a/_posts/2015-06-20-version-0.19.2.md
+++ b/_posts/2015-06-20-version-0.19.2.md
@@ -4,7 +4,7 @@ author: danielbachhuber
 title: Version 0.19.2 released
 ---
 
-Embarrassingly, [WP-CLI v0.19.1](http://wp-cli.org/blog/version-0.19.1.html) introduced another bug related to scaffolding plugin tests. More embarrassingly, it took me a full month to get around to fixing it. My apologies if you were bit by it.
+Embarrassingly, [WP-CLI v0.19.1](https://wp-cli.org/blog/version-0.19.1.html) introduced another bug related to scaffolding plugin tests. More embarrassingly, it took me a full month to get around to fixing it. My apologies if you were bit by it.
 
 You can browse the full list of [resolved issues](https://github.com/wp-cli/wp-cli/issues?milestone=31&page=1&state=closed) on Github.
 

--- a/_posts/2015-08-26-version-0.20.0.md
+++ b/_posts/2015-08-26-version-0.20.0.md
@@ -36,7 +36,7 @@ Use `wp core verify-checksums` to make sure a given WordPress install has the co
 
 ### WP-API CLI
 
-We [released v0.19.0](http://wp-cli.org/blog/version-0.19.0.html) with this statement:
+We [released v0.19.0](https://wp-cli.org/blog/version-0.19.0.html) with this statement:
 
 > WP-API is days away from 2.0-beta1, and brings with it a powerful new interface to WordPress. In the near future, we’ll start exploring how WP-CLI can use WP-API internally. If all goes well, WP-CLI could see just one more 0.x.0 release before the big 1.0.0.
 
@@ -48,7 +48,7 @@ There were a couple issues opened for "how do I do X?", which you might find hel
 
     # List plugins on each site in a network
     wp site list --field=url | xargs -n 1 -I % wp plugin list --url=%
-    
+
     # Delete inactive plugins
     wp plugin delete $(wp plugin list --status=inactive --field=name)
 

--- a/_posts/2015-10-30-version-0.20.3.md
+++ b/_posts/2015-10-30-version-0.20.3.md
@@ -4,11 +4,11 @@ author: danielbachhuber
 title: Version 0.20.3 released
 ---
 
-WordPress 4.4 loads a few new files in `wp-settings.php` relating to oEmbed and the REST API. Because WP-CLI has a custom `wp-settings-cli.php` ([background](http://wp-cli.org/blog/how-wp-cli-loads-wordpress.html)), WP-CLI v0.20.3 is a compatibility release to load these new files.
+WordPress 4.4 loads a few new files in `wp-settings.php` relating to oEmbed and the REST API. Because WP-CLI has a custom `wp-settings-cli.php` ([background](https://wp-cli.org/blog/how-wp-cli-loads-wordpress.html)), WP-CLI v0.20.3 is a compatibility release to load these new files.
 
 **Importantly, due to the nature of these changes, WP-CLI versions prior to 0.20.3 will be incompatible with WordPress 4.4.**
 
-Stay tuned next week for WP-CLI v0.21.0 (which is also compatible with WordPress 4.4), the results of the [user survey](http://wp-cli.org/blog/user-survey-2015.html), and a special announcement.
+Stay tuned next week for WP-CLI v0.21.0 (which is also compatible with WordPress 4.4), the results of the [user survey](https://wp-cli.org/blog/user-survey-2015.html), and a special announcement.
 
 You can browse the full list of [resolved issues](https://github.com/wp-cli/wp-cli/issues?q=is%3Aclosed+milestone%3A0.20.2) on Github.
 

--- a/_posts/2015-11-04-version-0.21.0.md
+++ b/_posts/2015-11-04-version-0.21.0.md
@@ -11,7 +11,7 @@ As many of you are aware of, I launched a Kickstarter campaign Monday night: [A 
 But, I have an even more **important note** about supported WordPress versions:
 
 * WP-CLI v0.22.0 (the next release) will bump the minimum supported WordPress version from 3.5 to 3.7 ([background](https://github.com/wp-cli/wp-cli/issues/2134)).
-* WP-CLI versions prior to 0.20.3 will be incompatible with WordPress 4.4 ([background](http://wp-cli.org/blog/version-0.20.3.html)).
+* WP-CLI versions prior to 0.20.3 will be incompatible with WordPress 4.4 ([background](https://wp-cli.org/blog/version-0.20.3.html)).
 
 This important note may apply to you in some way -- please take action accordingly.
 
@@ -24,7 +24,7 @@ For a while now, you've been able to run a WP-CLI command before WordPress loads
 See how `wp eval` makes use of `WP_CLI::get_runner()->load_wordpress()`:
 
     class Eval_Command extends WP_CLI_Command {
-        
+
         /**
          * Execute arbitrary PHP code.
          *

--- a/_posts/2015-11-23-versions-0.21.1-and-0.20.4.md
+++ b/_posts/2015-11-23-versions-0.21.1-and-0.20.4.md
@@ -4,7 +4,7 @@ author: danielbachhuber
 title: Versions 0.21.1 and 0.20.4 released
 ---
 
-WordPress 4.4 loads a <del>few new files</del> <ins>even more files</ins> in `wp-settings.php`. Because WP-CLI has a custom `wp-settings-cli.php` ([background](http://wp-cli.org/blog/how-wp-cli-loads-wordpress.html)), WP-CLI v0.21.1 and v0.20.4 are compatibility releases to load these new files.
+WordPress 4.4 loads a <del>few new files</del> <ins>even more files</ins> in `wp-settings.php`. Because WP-CLI has a custom `wp-settings-cli.php` ([background](https://wp-cli.org/blog/how-wp-cli-loads-wordpress.html)), WP-CLI v0.21.1 and v0.20.4 are compatibility releases to load these new files.
 
 **Importantly, due to the nature of these changes, WP-CLI versions prior to 0.20.4 will be incompatible with WordPress 4.4.**
 

--- a/_posts/2015-12-01-survey-results-2015.md
+++ b/_posts/2015-12-01-survey-results-2015.md
@@ -4,9 +4,9 @@ author: danielbachhuber
 title: What the survey said, 2015 edition
 ---
 
-Many thanks to the 206 (!!!) people who took our [second user survey](http://wp-cli.org/blog/user-survey-2015.html). We appreciate your time in helping us to understand how WP-CLI is being adopted by the community.
+Many thanks to the 206 (!!!) people who took our [second user survey](https://wp-cli.org/blog/user-survey-2015.html). We appreciate your time in helping us to understand how WP-CLI is being adopted by the community.
 
-Curious as to how the numbers have changed? Take a look at the [summary of the first user survey](http://wp-cli.org/blog/survey-results.html) from April 2014.
+Curious as to how the numbers have changed? Take a look at the [summary of the first user survey](https://wp-cli.org/blog/survey-results.html) from April 2014.
 
 ### By the numbers
 

--- a/_posts/2016-02-04-restful-wp-cli-update-2.md
+++ b/_posts/2016-02-04-restful-wp-cli-update-2.md
@@ -55,7 +55,7 @@ Wait, `wp package install`. What in the?
 
 That's right, WP-CLI now has package management. Using `wp cli update --nightly`, you now can:
 
-* `wp package browse` to browse [packages available for installation](http://wp-cli.org/package-index/).
+* `wp package browse` to browse [packages available for installation](https://wp-cli.org/package-index/).
 * `wp package install` to install a given package.
 * `wp package list` to list packages installed locally.
 * `wp package uninstall` to uninstall a given package.

--- a/_posts/2016-03-22-version-0.23.0.md
+++ b/_posts/2016-03-22-version-0.23.0.md
@@ -9,9 +9,9 @@ It's hard to believe the last WP-CLI release was only two months ago because thi
 If you don't make it all of the way through, here's what you absolutely need to know about WP-CLI v0.23.0:
 
 * This release includes WordPress 4.5 compatibility. Older WP-CLI versions are incompatible with WordPress 4.5. If you're planning to use WordPress 4.5 in the future, you'll need to upgrade before you do.
-* You can now browse [available packages](http://wp-cli.org/package-index/) with `wp package browse`, and install them with `wp package install`. Try `wp package install runcommand/db-ack`.
-* There are many new tools for registering commands. Ain't no more need to extend `WP_CLI_Command`. See the [commands cookbook](http://wp-cli.org/docs/commands-cookbook/) to learn more.
-* All of the wiki pages moved to a [documentation portal on the website](http://wp-cli.org/docs/), including new pages documenting [internal APIs](http://wp-cli.org/docs/internal-api/) you can use in your own commands. Pull requests encouraged.
+* You can now browse [available packages](https://wp-cli.org/package-index/) with `wp package browse`, and install them with `wp package install`. Try `wp package install runcommand/db-ack`.
+* There are many new tools for registering commands. Ain't no more need to extend `WP_CLI_Command`. See the [commands cookbook](https://wp-cli.org/docs/commands-cookbook/) to learn more.
+* All of the wiki pages moved to a [documentation portal on the website](https://wp-cli.org/docs/), including new pages documenting [internal APIs](https://wp-cli.org/docs/internal-api/) you can use in your own commands. Pull requests encouraged.
 
 Now that I've given away all of the surpises, let's get on with the release post.
 
@@ -24,7 +24,7 @@ And now, the release post.
 
 ### WordPress 4.5 compatibility
 
-WordPress 4.5 loads yet another file in `wp-settings.php`. Because WP-CLI has a custom wp-settings-cli.php ([background](http://wp-cli.org/blog/how-wp-cli-loads-wordpress.html)), WP-CLI v0.23.0 is the only release compatible with WordPress 4.5.
+WordPress 4.5 loads yet another file in `wp-settings.php`. Because WP-CLI has a custom wp-settings-cli.php ([background](https://wp-cli.org/blog/how-wp-cli-loads-wordpress.html)), WP-CLI v0.23.0 is the only release compatible with WordPress 4.5.
 
 **Importantly, due to the nature of these changes, WP-CLI versions prior to 0.23.0 will be incompatible with WordPress 4.5.**
 
@@ -46,7 +46,7 @@ If you had to complete this task using the WordPress network admin, it would tak
 
 WP-CLI also generally follows the 80/20 rule when deciding whether to introduce a new feature. If the feature could be useful to most people, then maybe; otherwise, probably not. Those 20% shouldn't be left with the short stick though, particularly when it comes to the really helpful commands.
 
-Today, I'm proud to reintroduce the [Package Index](http://wp-cli.org/package-index/), a directory of community-maintained WP-CLI packages. Browse available packages to install with `wp package browse` ([doc](http://wp-cli.org/commands/package/browse/)). Once you've found the solution you're looking for, install it with `wp package install` ([doc](http://wp-cli.org/commands/package/install/)):
+Today, I'm proud to reintroduce the [Package Index](https://wp-cli.org/package-index/), a directory of community-maintained WP-CLI packages. Browse available packages to install with `wp package browse` ([doc](https://wp-cli.org/commands/package/browse/)). Once you've found the solution you're looking for, install it with `wp package install` ([doc](https://wp-cli.org/commands/package/install/)):
 
     $ wp package install runcommand/find-unused-themes
     Installing runcommand/find-unused-themes (dev-master)
@@ -86,7 +86,7 @@ Relevant pull requests for `wp package` include [#2442](https://github.com/wp-cl
 
 Ever wonder why, when writing your own command, you had to extend `WP_CLI_Command`? Well, you didn't need to, actually.
 
-In fact, `WP_CLI::add_command()` ([doc](http://wp-cli.org/docs/internal-api/wp-cli-add-command/)) now supports registering any arbitrary callable as a WP-CLI command. For instance, here's a closure command to reset the passwords of one or more users ([runcommand/reset-passwords](https://github.com/runcommand/reset-passwords)):
+In fact, `WP_CLI::add_command()` ([doc](https://wp-cli.org/docs/internal-api/wp-cli-add-command/)) now supports registering any arbitrary callable as a WP-CLI command. For instance, here's a closure command to reset the passwords of one or more users ([runcommand/reset-passwords](https://github.com/runcommand/reset-passwords)):
 
     /**
      * Reset passwords for one or more WordPress users.
@@ -146,14 +146,14 @@ Note the `default` argument attribute for `format`. WP-CLI accepts `default` and
      */
     $hook_command = function( $args, $assoc_args ) {
 
-Check out the [commands cookbook](http://wp-cli.org/docs/commands-cookbook/) for a deep dive into command registration. Relevant pull requests for these improvements to `WP_CLI::add_command()` include [#2373](https://github.com/wp-cli/wp-cli/pull/2373), [#2389](https://github.com/wp-cli/wp-cli/pull/2389), [#2398](https://github.com/wp-cli/wp-cli/pull/2398), [#2409](https://github.com/wp-cli/wp-cli/pull/2409), [#2556](https://github.com/wp-cli/wp-cli/pull/2556), [#2559](https://github.com/wp-cli/wp-cli/pull/2559).
+Check out the [commands cookbook](https://wp-cli.org/docs/commands-cookbook/) for a deep dive into command registration. Relevant pull requests for these improvements to `WP_CLI::add_command()` include [#2373](https://github.com/wp-cli/wp-cli/pull/2373), [#2389](https://github.com/wp-cli/wp-cli/pull/2389), [#2398](https://github.com/wp-cli/wp-cli/pull/2398), [#2409](https://github.com/wp-cli/wp-cli/pull/2409), [#2556](https://github.com/wp-cli/wp-cli/pull/2556), [#2559](https://github.com/wp-cli/wp-cli/pull/2559).
 
 ### More, better, easier to find documentation
 
 It's actually hard to imagine how people got around previously. Here's what's changed in documentationland:
 
-* The wiki has been reincarnated as the [documentation portal](http://wp-cli.org/docs/) on the website. I spent time cleaning up the pages as I moved them over; hopefully you find the new [commands cookbook](http://wp-cli.org/docs/commands-cookbook/) quite helpful.
-* Internal APIs you can use in your own commands are now [publicly documented](http://wp-cli.org/docs/internal-api/). The internal API pages are generated from the codebase, which should greatly help maintenance efforts.
+* The wiki has been reincarnated as the [documentation portal](https://wp-cli.org/docs/) on the website. I spent time cleaning up the pages as I moved them over; hopefully you find the new [commands cookbook](https://wp-cli.org/docs/commands-cookbook/) quite helpful.
+* Internal APIs you can use in your own commands are now [publicly documented](https://wp-cli.org/docs/internal-api/). The internal API pages are generated from the codebase, which should greatly help maintenance efforts.
 * On each command page, there's a "Github issues" link to make it easier to find both open and closed issues for a given command. For instance, here are [all of the outstanding issues](https://github.com/wp-cli/wp-cli/issues?q=is%3Aopen+label%3Acommand%3Apackage+sort%3Aupdated-desc) for `wp package` and its subcommands. Keep in mind this isn't necessarily exact, because I didn't go back through and label all issues of all time. This feature will become more useful as time goes forward.
 
 Relevant pull requests include [#2454](https://github.com/wp-cli/wp-cli/pull/2454), [#2487](https://github.com/wp-cli/wp-cli/pull/2487), [#2494](https://github.com/wp-cli/wp-cli/pull/2494), [#2499](https://github.com/wp-cli/wp-cli/pull/2499), [#2507](https://github.com/wp-cli/wp-cli/pull/2507), [#2513](https://github.com/wp-cli/wp-cli/pull/2513), [#2515](https://github.com/wp-cli/wp-cli/pull/2515).

--- a/_posts/2016-04-14-restful-wp-cli-update-3.md
+++ b/_posts/2016-04-14-restful-wp-cli-update-3.md
@@ -4,7 +4,7 @@ author: danielbachhuber
 title: RESTful WP-CLI - What I've been hacking on
 ---
 
-Let me just say — Thursday, February 4th was [pretty darn demoralizing](https://twitter.com/Krogsgard/status/695634320401285121). I spent a huge amount of time in January towards the WP REST API in preparation for what I wanted to do on the command line, and a lot of momentum / inspiration / general good feelings were destroyed in that meeting. As such, I spent much of February and March working on WP-CLI features unrelated to the WP REST API (e.g. [package management](http://wp-cli.org/commands/package/)).
+Let me just say — Thursday, February 4th was [pretty darn demoralizing](https://twitter.com/Krogsgard/status/695634320401285121). I spent a huge amount of time in January towards the WP REST API in preparation for what I wanted to do on the command line, and a lot of momentum / inspiration / general good feelings were destroyed in that meeting. As such, I spent much of February and March working on WP-CLI features unrelated to the WP REST API (e.g. [package management](https://wp-cli.org/commands/package/)).
 
 But, I'm back in the saddle. Because I'm 2/3 of the way through one of those fancy WP REST API + React WordPress applications, I'm running into dozens of ways I want to be able to make WordPress more efficiently. And of course, this means doing it on the command line.
 

--- a/_posts/2016-07-27-version-0.24.0.md
+++ b/_posts/2016-07-27-version-0.24.0.md
@@ -13,7 +13,7 @@ As I [mentioned in my WordCamp Europe talk](https://runcommand.io/2016/06/26/my-
 
 In this model, WP-CLI becomes the common interface, and supporting application layer, to a rich ecosystem of features. Doing so opens more frontiers for innovation, which leads to a greater selection of ideas to choose from. And because more people are involved in authoring packages, WP-CLI benefits from a larger contributor pool.
 
-With this model, my focus shifts towards designing a world-class experience for WP-CLI package authorship. Read through the [commands cookbook](http://wp-cli.org/docs/commands-cookbook/) for a thorough introduction to creating a WP-CLI command. Check out `wp scaffold package` [[repo](https://github.com/wp-cli/scaffold-package-command)] for the easiest way to generate the boilerplate for your new WP-CLI package. Weigh in with your thoughts on [how we should evolve the WP-CLI package index](https://github.com/wp-cli/wp-cli/issues/3197). And [follow @runcommand](https://twitter.com/runcommand) as I explore commercializing WP-CLI products and services — I hope that [runcommand](https://runcommand.io) is just the first of several WP-CLI-based businesses.
+With this model, my focus shifts towards designing a world-class experience for WP-CLI package authorship. Read through the [commands cookbook](https://wp-cli.org/docs/commands-cookbook/) for a thorough introduction to creating a WP-CLI command. Check out `wp scaffold package` [[repo](https://github.com/wp-cli/scaffold-package-command)] for the easiest way to generate the boilerplate for your new WP-CLI package. Weigh in with your thoughts on [how we should evolve the WP-CLI package index](https://github.com/wp-cli/wp-cli/issues/3197). And [follow @runcommand](https://twitter.com/runcommand) as I explore commercializing WP-CLI products and services — I hope that [runcommand](https://runcommand.io) is just the first of several WP-CLI-based businesses.
 
 One last ask: if you care about the WP-CLI release cycle, or dependencies and backwards compatibility, please [let me know how often you think WP-CLI should be released](https://github.com/wp-cli/wp-cli/issues/3198).
 
@@ -23,7 +23,7 @@ Let's get on with the show. Use `wp cli update` to install v0.24.0, representing
 
 Every application has a bootstrap file which loads all of the requisite utilities needed to serve a request. In WordPress, this is called `wp-settings.php`.
 
-Since v0.8.0 [[#261](https://github.com/wp-cli/wp-cli/pull/261)], WP-CLI has used a forked version of this bootstrap file, called `wp-settings-cli.php`, to give it more control over the load process, providing features like `--skip-plugins`. But, because WordPress can require new files from `wp-settings.php`, maintaining a forked version has the unfortunate side effect of WP-CLI [regularly breaking when a new version of WordPress is released](http://wp-cli.org/blog/versions-0.21.1-and-0.20.4.html).
+Since v0.8.0 [[#261](https://github.com/wp-cli/wp-cli/pull/261)], WP-CLI has used a forked version of this bootstrap file, called `wp-settings-cli.php`, to give it more control over the load process, providing features like `--skip-plugins`. But, because WordPress can require new files from `wp-settings.php`, maintaining a forked version has the unfortunate side effect of WP-CLI [regularly breaking when a new version of WordPress is released](https://wp-cli.org/blog/versions-0.21.1-and-0.20.4.html).
 
 Thanks to coordinated changes in the WordPress project, WP-CLI v0.24.0 returns to loading `wp-settings.php` for WordPress 4.6 and higher [[#2278](https://github.com/wp-cli/wp-cli/issues/2278)]. Doing so should make WP-CLI more future proof against new versions of WordPress.
 
@@ -32,8 +32,8 @@ Thanks to coordinated changes in the WordPress project, WP-CLI v0.24.0 returns t
 Thanks to tireless efforts by a solid group of contributors, WP-CLI now has more documentation in more languages.
 
 * Dozens of commands have improved examples for reference.
-* We have a new [CONTRIBUTING.md](https://github.com/wp-cli/wp-cli/blob/master/CONTRIBUTING.md), which also has a [page on the website](http://wp-cli.org/docs/contributing/).
-* Our new [README.md](https://github.com/wp-cli/wp-cli/blob/master/README.md) powers the [WP-CLI homepage](http://wp-cli.org/), and is available in [Japanese](http://wp-cli.org/ja/), [Français](http://wp-cli.org/fr/), [Português (Brasil)](http://wp-cli.org/br/), [Türkçe](http://wp-cli.org/tr/), [Deutsch](http://wp-cli.org/de/), [नेपाली](http://wp-cli.org/ne/), and [ελληνικά](http://wp-cli.org/gr/).
+* We have a new [CONTRIBUTING.md](https://github.com/wp-cli/wp-cli/blob/master/CONTRIBUTING.md), which also has a [page on the website](https://wp-cli.org/docs/contributing/).
+* Our new [README.md](https://github.com/wp-cli/wp-cli/blob/master/README.md) powers the [WP-CLI homepage](https://wp-cli.org/), and is available in [Japanese](https://wp-cli.org/ja/), [Français](https://wp-cli.org/fr/), [Português (Brasil)](https://wp-cli.org/br/), [Türkçe](https://wp-cli.org/tr/), [Deutsch](https://wp-cli.org/de/), [नेपाली](https://wp-cli.org/ne/), and [ελληνικά](https://wp-cli.org/gr/).
 
 Want to get involved with WP-CLI's documentation? Check out the [Github issues labeled "scope:documentation"](https://github.com/wp-cli/wp-cli/issues?q=is%3Aopen+sort%3Aupdated-desc+label%3Ascope%3Adocumentation).
 

--- a/_posts/2016-12-12-the-big-question.md
+++ b/_posts/2016-12-12-the-big-question.md
@@ -29,7 +29,7 @@ So, dear reader, a question: how much is WP-CLI worth to you?
 
 Or, phrased another way, how much time does WP-CLI save you?
 
-If the experiment goes well, then we're in business! Your purchase will support ongoing maintenance of WP-CLI, as well as development of new commands like [wp doctor](https://runcommand.io/wp/doctor/) and [wp profile](https://runcommand.io/wp/profile/), [improvements to the website and package index](http://wp-cli.org/docs/wish-list/), and so on.
+If the experiment goes well, then we're in business! Your purchase will support ongoing maintenance of WP-CLI, as well as development of new commands like [wp doctor](https://runcommand.io/wp/doctor/) and [wp profile](https://runcommand.io/wp/profile/), [improvements to the website and package index](https://wp-cli.org/docs/wish-list/), and so on.
 
 If the experiment doesn't go well, then at least I can say I tried :) To avoid any risk with the investment above, a full refund will be made available to you should the campaign not reach its goal, before we look at other approaches to help with maintaining the project.
 

--- a/_posts/2016-12-28-supporting-the-future-of-wp-cli.md
+++ b/_posts/2016-12-28-supporting-the-future-of-wp-cli.md
@@ -12,7 +12,7 @@ To that end there are two big announcements:
 
 1. The website of wp-cli.org, the code / Github, Twitter, and such are all coming in under the WordPress.org umbrella and there will be a CLI Make site with a P2 and all of the resources that used to be under wp-cli.org. There is already #cli on Slack and that will continue. (Will live at [https://make.wordpress.org/cli](https://make.wordpress.org/cli).)
 
-2. I’m going to be bringing together a number of companies in the WordPress ecosystem to solidify their financial support of runcommand so that Daniel and others can devote more time to making wp-cli better and better through 2017. This is a continuation of [the fundraising started a few weeks ago](http://wp-cli.org/blog/the-big-question.html).
+2. I’m going to be bringing together a number of companies in the WordPress ecosystem to solidify their financial support of runcommand so that Daniel and others can devote more time to making wp-cli better and better through 2017. This is a continuation of [the fundraising started a few weeks ago](https://wp-cli.org/blog/the-big-question.html).
 
 This will all happen the first part of January, and I’m looking to a full and exciting year for wp-cli. Also big thanks to everyone who has chipped in, whether time or money, to support the project in the past. It has been one of the highest impact developments for WP in many years.
 

--- a/fr/index.md
+++ b/fr/index.md
@@ -156,7 +156,7 @@ $delete_option_cmd = function( $args ) {
 WP_CLI::add_command( 'option delete', $delete_option_cmd );
 ```
 
-WP-CLI est livré avec des douzaines de commandes. Il est plus facile qu'il n'y parait de créer vos propres commandes WP-CLI. Lisez le [commands cookbook](https://wp-cli.org/docs/commands-cookbook/) pour en apprendre d'avantage. Parcourez la [documentation sur l'API interne](http://wp-cli.org/docs/internal-api/) pour découvrir une variété de fonctions utiles que vous pouvez utiliser dans votre commande WP-CLI personnalisée.
+WP-CLI est livré avec des douzaines de commandes. Il est plus facile qu'il n'y parait de créer vos propres commandes WP-CLI. Lisez le [commands cookbook](https://wp-cli.org/docs/commands-cookbook/) pour en apprendre d'avantage. Parcourez la [documentation sur l'API interne](https://wp-cli.org/docs/internal-api/) pour découvrir une variété de fonctions utiles que vous pouvez utiliser dans votre commande WP-CLI personnalisée.
 
 ## Contribuer
 

--- a/restful/index.md
+++ b/restful/index.md
@@ -43,7 +43,7 @@ Just like WordPress has plugins, the future of WP-CLI is [packages of commands](
 
 In this model, WP-CLI becomes the common interface, and supporting application layer, to a rich ecosystem of features. Doing so opens more frontiers for innovation, which leads to a greater selection of ideas to choose from. And because more people are involved in authoring packages, WP-CLI benefits from a larger contributor pool.
 
-As a result of the Kickstarter project, you can install WP-CLI packages from the Package Index with `wp package install`, [read through the commands cookbook](http://wp-cli.org/docs/commands-cookbook/) for a thorough introduction to creating a WP-CLI command, or use `wp scaffold package` ([repo](https://github.com/wp-cli/scaffold-package-command)) for the easiest way to generate the boilerplate for your new WP-CLI package, complete with functional tests.
+As a result of the Kickstarter project, you can install WP-CLI packages from the Package Index with `wp package install`, [read through the commands cookbook](https://wp-cli.org/docs/commands-cookbook/) for a thorough introduction to creating a WP-CLI command, or use `wp scaffold package` ([repo](https://github.com/wp-cli/scaffold-package-command)) for the easiest way to generate the boilerplate for your new WP-CLI package, complete with functional tests.
 
 ### Documentation portal
 


### PR DESCRIPTION
[wp-cli package-index page](https://wp-cli.org/package-index/) shows following error in console: 
![screen shot 2018-02-28 at 1 53 28 pm](https://user-images.githubusercontent.com/8456197/36777262-dfd00ede-1c8e-11e8-8760-e227b45283ca.png)

```
Mixed Content: The page at 'https://wp-cli.org/package-index/' was loaded over HTTPS, but requested an insecure stylesheet 'http://wp-cli.org/assets/css/fa.css'. This request has been blocked; the content must be served over HTTPS
```

This occurs due to `url` paramater in `_config.yml` which pointed to `http://wp-cli.org` site.

I modified it and changed it to https and also took this opportunity to modify other such `http://wp-cli.org` links to `https`.
