### PR TITLE
Restore command pages to redirect to developer.wordpress.org URLs

### DIFF
--- a/commands/blog/create/index.md
+++ b/commands/blog/create/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/blog/create/

--- a/commands/blog/delete/index.md
+++ b/commands/blog/delete/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/blog/delete/

--- a/commands/blog/empty/index.md
+++ b/commands/blog/empty/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/blog/empty/

--- a/commands/blog/index.md
+++ b/commands/blog/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/blog/

--- a/commands/cache/add/index.md
+++ b/commands/cache/add/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/cache/add/

--- a/commands/cache/decr/index.md
+++ b/commands/cache/decr/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/cache/decr/

--- a/commands/cache/delete/index.md
+++ b/commands/cache/delete/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/cache/delete/

--- a/commands/cache/flush/index.md
+++ b/commands/cache/flush/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/cache/flush/

--- a/commands/cache/get/index.md
+++ b/commands/cache/get/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/cache/get/

--- a/commands/cache/incr/index.md
+++ b/commands/cache/incr/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/cache/incr/

--- a/commands/cache/index.md
+++ b/commands/cache/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/cache/

--- a/commands/cache/replace/index.md
+++ b/commands/cache/replace/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/cache/replace/

--- a/commands/cache/set/index.md
+++ b/commands/cache/set/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/cache/set/

--- a/commands/cache/type/index.md
+++ b/commands/cache/type/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/cache/type/

--- a/commands/cap/add/index.md
+++ b/commands/cap/add/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/cap/add/

--- a/commands/cap/index.md
+++ b/commands/cap/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/cap/

--- a/commands/cap/list/index.md
+++ b/commands/cap/list/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/cap/list/

--- a/commands/cap/remove/index.md
+++ b/commands/cap/remove/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/cap/remove/

--- a/commands/cli/alias/index.md
+++ b/commands/cli/alias/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/cli/alias/

--- a/commands/cli/check-update/index.md
+++ b/commands/cli/check-update/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/cli/check-update/

--- a/commands/cli/cmd-dump/index.md
+++ b/commands/cli/cmd-dump/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/cli/cmd-dump/

--- a/commands/cli/completions/index.md
+++ b/commands/cli/completions/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/cli/completions/

--- a/commands/cli/index.md
+++ b/commands/cli/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/cli/

--- a/commands/cli/info/index.md
+++ b/commands/cli/info/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/cli/info/

--- a/commands/cli/param-dump/index.md
+++ b/commands/cli/param-dump/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/cli/param-dump/

--- a/commands/cli/update/index.md
+++ b/commands/cli/update/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/cli/update/

--- a/commands/cli/version/index.md
+++ b/commands/cli/version/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/cli/version/

--- a/commands/comment/approve/index.md
+++ b/commands/comment/approve/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/comment/approve/

--- a/commands/comment/count/index.md
+++ b/commands/comment/count/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/comment/count/

--- a/commands/comment/create/index.md
+++ b/commands/comment/create/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/comment/create/

--- a/commands/comment/delete/index.md
+++ b/commands/comment/delete/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/comment/delete/

--- a/commands/comment/exists/index.md
+++ b/commands/comment/exists/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/comment/exists/

--- a/commands/comment/generate/index.md
+++ b/commands/comment/generate/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/comment/generate/

--- a/commands/comment/get/index.md
+++ b/commands/comment/get/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/comment/get/

--- a/commands/comment/index.md
+++ b/commands/comment/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/comment/

--- a/commands/comment/list/index.md
+++ b/commands/comment/list/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/comment/list/

--- a/commands/comment/meta/add/index.md
+++ b/commands/comment/meta/add/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/comment/meta/add/

--- a/commands/comment/meta/delete/index.md
+++ b/commands/comment/meta/delete/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/comment/meta/delete/

--- a/commands/comment/meta/get/index.md
+++ b/commands/comment/meta/get/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/comment/meta/get/

--- a/commands/comment/meta/index.md
+++ b/commands/comment/meta/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/comment/meta/

--- a/commands/comment/meta/list/index.md
+++ b/commands/comment/meta/list/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/comment/meta/list/

--- a/commands/comment/meta/update/index.md
+++ b/commands/comment/meta/update/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/comment/meta/update/

--- a/commands/comment/recount/index.md
+++ b/commands/comment/recount/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/comment/recount/

--- a/commands/comment/spam/index.md
+++ b/commands/comment/spam/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/comment/spam/

--- a/commands/comment/status/index.md
+++ b/commands/comment/status/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/comment/status/

--- a/commands/comment/trash/index.md
+++ b/commands/comment/trash/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/comment/trash/

--- a/commands/comment/unapprove/index.md
+++ b/commands/comment/unapprove/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/comment/unapprove/

--- a/commands/comment/unspam/index.md
+++ b/commands/comment/unspam/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/comment/unspam/

--- a/commands/comment/untrash/index.md
+++ b/commands/comment/untrash/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/comment/untrash/

--- a/commands/comment/update/index.md
+++ b/commands/comment/update/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/comment/update/

--- a/commands/core/check-update/index.md
+++ b/commands/core/check-update/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/core/check-update/

--- a/commands/core/config/index.md
+++ b/commands/core/config/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/core/config/

--- a/commands/core/download/index.md
+++ b/commands/core/download/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/core/download/

--- a/commands/core/index.md
+++ b/commands/core/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/core/

--- a/commands/core/install-network/index.md
+++ b/commands/core/install-network/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/core/install-network/

--- a/commands/core/install/index.md
+++ b/commands/core/install/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/core/install/

--- a/commands/core/is-installed/index.md
+++ b/commands/core/is-installed/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/core/is-installed/

--- a/commands/core/language/activate/index.md
+++ b/commands/core/language/activate/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/core/language/activate/

--- a/commands/core/language/index.md
+++ b/commands/core/language/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/core/language/

--- a/commands/core/language/install/index.md
+++ b/commands/core/language/install/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/core/language/install/

--- a/commands/core/language/list/index.md
+++ b/commands/core/language/list/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/core/language/list/

--- a/commands/core/language/uninstall/index.md
+++ b/commands/core/language/uninstall/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/core/language/uninstall/

--- a/commands/core/language/update/index.md
+++ b/commands/core/language/update/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/core/language/update/

--- a/commands/core/multisite-convert/index.md
+++ b/commands/core/multisite-convert/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/core/multisite-convert/

--- a/commands/core/multisite-install/index.md
+++ b/commands/core/multisite-install/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/core/multisite-install/

--- a/commands/core/update-db/index.md
+++ b/commands/core/update-db/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/core/update-db/

--- a/commands/core/update/index.md
+++ b/commands/core/update/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/core/update/

--- a/commands/core/verify-checksums/index.md
+++ b/commands/core/verify-checksums/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/core/verify-checksums/

--- a/commands/core/version/index.md
+++ b/commands/core/version/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/core/version/

--- a/commands/cron/event/delete/index.md
+++ b/commands/cron/event/delete/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/cron/event/delete/

--- a/commands/cron/event/index.md
+++ b/commands/cron/event/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/cron/event/

--- a/commands/cron/event/list/index.md
+++ b/commands/cron/event/list/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/cron/event/list/

--- a/commands/cron/event/run/index.md
+++ b/commands/cron/event/run/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/cron/event/run/

--- a/commands/cron/event/schedule/index.md
+++ b/commands/cron/event/schedule/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/cron/event/schedule/

--- a/commands/cron/index.md
+++ b/commands/cron/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/cron/

--- a/commands/cron/schedule/index.md
+++ b/commands/cron/schedule/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/cron/schedule/

--- a/commands/cron/schedule/list/index.md
+++ b/commands/cron/schedule/list/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/cron/schedule/list/

--- a/commands/cron/test/index.md
+++ b/commands/cron/test/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/cron/test/

--- a/commands/db/check/index.md
+++ b/commands/db/check/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/db/check/

--- a/commands/db/cli/index.md
+++ b/commands/db/cli/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/db/cli/

--- a/commands/db/create/index.md
+++ b/commands/db/create/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/db/create/

--- a/commands/db/drop/index.md
+++ b/commands/db/drop/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/db/drop/

--- a/commands/db/export/index.md
+++ b/commands/db/export/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/db/export/

--- a/commands/db/import/index.md
+++ b/commands/db/import/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/db/import/

--- a/commands/db/index.md
+++ b/commands/db/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/db/

--- a/commands/db/optimize/index.md
+++ b/commands/db/optimize/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/db/optimize/

--- a/commands/db/query/index.md
+++ b/commands/db/query/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/db/query/

--- a/commands/db/repair/index.md
+++ b/commands/db/repair/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/db/repair/

--- a/commands/db/reset/index.md
+++ b/commands/db/reset/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/db/reset/

--- a/commands/db/tables/index.md
+++ b/commands/db/tables/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/db/tables/

--- a/commands/eval-file/index.md
+++ b/commands/eval-file/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/eval-file/

--- a/commands/eval/index.md
+++ b/commands/eval/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/eval/

--- a/commands/export/index.md
+++ b/commands/export/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/export/

--- a/commands/help/index.md
+++ b/commands/help/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/help/

--- a/commands/import/index.md
+++ b/commands/import/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/import/

--- a/commands/media/import/index.md
+++ b/commands/media/import/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/media/import/

--- a/commands/media/index.md
+++ b/commands/media/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/media/

--- a/commands/media/regenerate/index.md
+++ b/commands/media/regenerate/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/media/regenerate/

--- a/commands/menu/create/index.md
+++ b/commands/menu/create/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/menu/create/

--- a/commands/menu/delete/index.md
+++ b/commands/menu/delete/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/menu/delete/

--- a/commands/menu/index.md
+++ b/commands/menu/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/menu/

--- a/commands/menu/item/add-custom/index.md
+++ b/commands/menu/item/add-custom/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/menu/item/add-custom/

--- a/commands/menu/item/add-post/index.md
+++ b/commands/menu/item/add-post/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/menu/item/add-post/

--- a/commands/menu/item/add-term/index.md
+++ b/commands/menu/item/add-term/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/menu/item/add-term/

--- a/commands/menu/item/delete/index.md
+++ b/commands/menu/item/delete/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/menu/item/delete/

--- a/commands/menu/item/index.md
+++ b/commands/menu/item/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/menu/item/

--- a/commands/menu/item/list/index.md
+++ b/commands/menu/item/list/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/menu/item/list/

--- a/commands/menu/item/update/index.md
+++ b/commands/menu/item/update/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/menu/item/update/

--- a/commands/menu/list/index.md
+++ b/commands/menu/list/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/menu/list/

--- a/commands/menu/location/assign/index.md
+++ b/commands/menu/location/assign/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/menu/location/assign/

--- a/commands/menu/location/index.md
+++ b/commands/menu/location/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/menu/location/

--- a/commands/menu/location/list/index.md
+++ b/commands/menu/location/list/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/menu/location/list/

--- a/commands/menu/location/remove/index.md
+++ b/commands/menu/location/remove/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/menu/location/remove/

--- a/commands/network/index.md
+++ b/commands/network/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/network/

--- a/commands/network/meta/add/index.md
+++ b/commands/network/meta/add/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/network/meta/add/

--- a/commands/network/meta/delete/index.md
+++ b/commands/network/meta/delete/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/network/meta/delete/

--- a/commands/network/meta/get/index.md
+++ b/commands/network/meta/get/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/network/meta/get/

--- a/commands/network/meta/index.md
+++ b/commands/network/meta/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/network/meta/

--- a/commands/network/meta/list/index.md
+++ b/commands/network/meta/list/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/network/meta/list/

--- a/commands/network/meta/update/index.md
+++ b/commands/network/meta/update/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/network/meta/update/

--- a/commands/option/add/index.md
+++ b/commands/option/add/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/option/add/

--- a/commands/option/delete/index.md
+++ b/commands/option/delete/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/option/delete/

--- a/commands/option/get/index.md
+++ b/commands/option/get/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/option/get/

--- a/commands/option/index.md
+++ b/commands/option/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/option/

--- a/commands/option/list/index.md
+++ b/commands/option/list/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/option/list/

--- a/commands/option/update/index.md
+++ b/commands/option/update/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/option/update/

--- a/commands/package/browse/index.md
+++ b/commands/package/browse/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/package/browse/

--- a/commands/package/index.md
+++ b/commands/package/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/package/

--- a/commands/package/install/index.md
+++ b/commands/package/install/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/package/install/

--- a/commands/package/list/index.md
+++ b/commands/package/list/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/package/list/

--- a/commands/package/path/index.md
+++ b/commands/package/path/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/package/path/

--- a/commands/package/uninstall/index.md
+++ b/commands/package/uninstall/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/package/uninstall/

--- a/commands/package/update/index.md
+++ b/commands/package/update/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/package/update/

--- a/commands/plugin/activate/index.md
+++ b/commands/plugin/activate/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/plugin/activate/

--- a/commands/plugin/deactivate/index.md
+++ b/commands/plugin/deactivate/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/plugin/deactivate/

--- a/commands/plugin/delete/index.md
+++ b/commands/plugin/delete/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/plugin/delete/

--- a/commands/plugin/get/index.md
+++ b/commands/plugin/get/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/plugin/get/

--- a/commands/plugin/index.md
+++ b/commands/plugin/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/plugin/

--- a/commands/plugin/install/index.md
+++ b/commands/plugin/install/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/plugin/install/

--- a/commands/plugin/is-installed/index.md
+++ b/commands/plugin/is-installed/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/plugin/is-installed/

--- a/commands/plugin/list/index.md
+++ b/commands/plugin/list/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/plugin/list/

--- a/commands/plugin/path/index.md
+++ b/commands/plugin/path/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/plugin/path/

--- a/commands/plugin/search/index.md
+++ b/commands/plugin/search/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/plugin/search/

--- a/commands/plugin/status/index.md
+++ b/commands/plugin/status/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/plugin/status/

--- a/commands/plugin/toggle/index.md
+++ b/commands/plugin/toggle/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/plugin/toggle/

--- a/commands/plugin/uninstall/index.md
+++ b/commands/plugin/uninstall/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/plugin/uninstall/

--- a/commands/plugin/update-all/index.md
+++ b/commands/plugin/update-all/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/plugin/update-all/

--- a/commands/plugin/update/index.md
+++ b/commands/plugin/update/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/plugin/update/

--- a/commands/post-type/get/index.md
+++ b/commands/post-type/get/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/post-type/get/

--- a/commands/post-type/index.md
+++ b/commands/post-type/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/post-type/

--- a/commands/post-type/list/index.md
+++ b/commands/post-type/list/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/post-type/list/

--- a/commands/post/create/index.md
+++ b/commands/post/create/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/post/create/

--- a/commands/post/delete/index.md
+++ b/commands/post/delete/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/post/delete/

--- a/commands/post/edit/index.md
+++ b/commands/post/edit/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/post/edit/

--- a/commands/post/generate/index.md
+++ b/commands/post/generate/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/post/generate/

--- a/commands/post/get/index.md
+++ b/commands/post/get/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/post/get/

--- a/commands/post/index.md
+++ b/commands/post/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/post/

--- a/commands/post/list/index.md
+++ b/commands/post/list/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/post/list/

--- a/commands/post/meta/add/index.md
+++ b/commands/post/meta/add/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/post/meta/add/

--- a/commands/post/meta/delete/index.md
+++ b/commands/post/meta/delete/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/post/meta/delete/

--- a/commands/post/meta/get/index.md
+++ b/commands/post/meta/get/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/post/meta/get/

--- a/commands/post/meta/index.md
+++ b/commands/post/meta/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/post/meta/

--- a/commands/post/meta/list/index.md
+++ b/commands/post/meta/list/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/post/meta/list/

--- a/commands/post/meta/update/index.md
+++ b/commands/post/meta/update/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/post/meta/update/

--- a/commands/post/term/add/index.md
+++ b/commands/post/term/add/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/post/term/add/

--- a/commands/post/term/index.md
+++ b/commands/post/term/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/post/term/

--- a/commands/post/term/list/index.md
+++ b/commands/post/term/list/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/post/term/list/

--- a/commands/post/term/remove/index.md
+++ b/commands/post/term/remove/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/post/term/remove/

--- a/commands/post/term/set/index.md
+++ b/commands/post/term/set/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/post/term/set/

--- a/commands/post/update/index.md
+++ b/commands/post/update/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/post/update/

--- a/commands/rewrite/flush/index.md
+++ b/commands/rewrite/flush/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/rewrite/flush/

--- a/commands/rewrite/index.md
+++ b/commands/rewrite/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/rewrite/

--- a/commands/rewrite/list/index.md
+++ b/commands/rewrite/list/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/rewrite/list/

--- a/commands/rewrite/structure/index.md
+++ b/commands/rewrite/structure/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/rewrite/structure/

--- a/commands/role/create/index.md
+++ b/commands/role/create/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/role/create/

--- a/commands/role/delete/index.md
+++ b/commands/role/delete/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/role/delete/

--- a/commands/role/exists/index.md
+++ b/commands/role/exists/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/role/exists/

--- a/commands/role/index.md
+++ b/commands/role/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/role/

--- a/commands/role/list/index.md
+++ b/commands/role/list/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/role/list/

--- a/commands/role/reset/index.md
+++ b/commands/role/reset/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/role/reset/

--- a/commands/scaffold/_s/index.md
+++ b/commands/scaffold/_s/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/scaffold/_s/

--- a/commands/scaffold/child-theme/index.md
+++ b/commands/scaffold/child-theme/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/scaffold/child-theme/

--- a/commands/scaffold/index.md
+++ b/commands/scaffold/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/scaffold/

--- a/commands/scaffold/plugin-tests/index.md
+++ b/commands/scaffold/plugin-tests/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/scaffold/plugin-tests/

--- a/commands/scaffold/plugin/index.md
+++ b/commands/scaffold/plugin/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/scaffold/plugin/

--- a/commands/scaffold/post-type/index.md
+++ b/commands/scaffold/post-type/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/scaffold/post-type/

--- a/commands/scaffold/taxonomy/index.md
+++ b/commands/scaffold/taxonomy/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/scaffold/taxonomy/

--- a/commands/scaffold/theme-tests/index.md
+++ b/commands/scaffold/theme-tests/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/scaffold/theme-tests/

--- a/commands/search-replace/index.md
+++ b/commands/search-replace/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/search-replace/

--- a/commands/server/index.md
+++ b/commands/server/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/server/

--- a/commands/shell/index.md
+++ b/commands/shell/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/shell/

--- a/commands/sidebar/index.md
+++ b/commands/sidebar/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/sidebar/

--- a/commands/sidebar/list/index.md
+++ b/commands/sidebar/list/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/sidebar/list/

--- a/commands/site/activate/index.md
+++ b/commands/site/activate/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/site/activate/

--- a/commands/site/archive/index.md
+++ b/commands/site/archive/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/site/archive/

--- a/commands/site/create/index.md
+++ b/commands/site/create/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/site/create/

--- a/commands/site/deactivate/index.md
+++ b/commands/site/deactivate/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/site/deactivate/

--- a/commands/site/delete/index.md
+++ b/commands/site/delete/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/site/delete/

--- a/commands/site/empty/index.md
+++ b/commands/site/empty/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/site/empty/

--- a/commands/site/index.md
+++ b/commands/site/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/site/

--- a/commands/site/list/index.md
+++ b/commands/site/list/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/site/list/

--- a/commands/site/option/add/index.md
+++ b/commands/site/option/add/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/site/option/add/

--- a/commands/site/option/delete/index.md
+++ b/commands/site/option/delete/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/site/option/delete/

--- a/commands/site/option/get/index.md
+++ b/commands/site/option/get/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/site/option/get/

--- a/commands/site/option/index.md
+++ b/commands/site/option/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/site/option/

--- a/commands/site/option/list/index.md
+++ b/commands/site/option/list/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/site/option/list/

--- a/commands/site/option/update/index.md
+++ b/commands/site/option/update/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/site/option/update/

--- a/commands/site/spam/index.md
+++ b/commands/site/spam/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/site/spam/

--- a/commands/site/unarchive/index.md
+++ b/commands/site/unarchive/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/site/unarchive/

--- a/commands/site/unspam/index.md
+++ b/commands/site/unspam/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/site/unspam/

--- a/commands/super-admin/add/index.md
+++ b/commands/super-admin/add/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/super-admin/add/

--- a/commands/super-admin/index.md
+++ b/commands/super-admin/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/super-admin/

--- a/commands/super-admin/list/index.md
+++ b/commands/super-admin/list/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/super-admin/list/

--- a/commands/super-admin/remove/index.md
+++ b/commands/super-admin/remove/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/super-admin/remove/

--- a/commands/taxonomy/get/index.md
+++ b/commands/taxonomy/get/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/taxonomy/get/

--- a/commands/taxonomy/index.md
+++ b/commands/taxonomy/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/taxonomy/

--- a/commands/taxonomy/list/index.md
+++ b/commands/taxonomy/list/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/taxonomy/list/

--- a/commands/term/create/index.md
+++ b/commands/term/create/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/term/create/

--- a/commands/term/delete/index.md
+++ b/commands/term/delete/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/term/delete/

--- a/commands/term/generate/index.md
+++ b/commands/term/generate/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/term/generate/

--- a/commands/term/get/index.md
+++ b/commands/term/get/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/term/get/

--- a/commands/term/index.md
+++ b/commands/term/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/term/

--- a/commands/term/list/index.md
+++ b/commands/term/list/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/term/list/

--- a/commands/term/meta/add/index.md
+++ b/commands/term/meta/add/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/term/meta/add/

--- a/commands/term/meta/delete/index.md
+++ b/commands/term/meta/delete/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/term/meta/delete/

--- a/commands/term/meta/get/index.md
+++ b/commands/term/meta/get/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/term/meta/get/

--- a/commands/term/meta/index.md
+++ b/commands/term/meta/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/term/meta/

--- a/commands/term/meta/list/index.md
+++ b/commands/term/meta/list/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/term/meta/list/

--- a/commands/term/meta/update/index.md
+++ b/commands/term/meta/update/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/term/meta/update/

--- a/commands/term/recount/index.md
+++ b/commands/term/recount/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/term/recount/

--- a/commands/term/update/index.md
+++ b/commands/term/update/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/term/update/

--- a/commands/theme/activate/index.md
+++ b/commands/theme/activate/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/theme/activate/

--- a/commands/theme/delete/index.md
+++ b/commands/theme/delete/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/theme/delete/

--- a/commands/theme/disable/index.md
+++ b/commands/theme/disable/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/theme/disable/

--- a/commands/theme/enable/index.md
+++ b/commands/theme/enable/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/theme/enable/

--- a/commands/theme/get/index.md
+++ b/commands/theme/get/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/theme/get/

--- a/commands/theme/index.md
+++ b/commands/theme/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/theme/

--- a/commands/theme/install/index.md
+++ b/commands/theme/install/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/theme/install/

--- a/commands/theme/is-installed/index.md
+++ b/commands/theme/is-installed/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/theme/is-installed/

--- a/commands/theme/list/index.md
+++ b/commands/theme/list/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/theme/list/

--- a/commands/theme/mod/get/index.md
+++ b/commands/theme/mod/get/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/theme/mod/get/

--- a/commands/theme/mod/index.md
+++ b/commands/theme/mod/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/theme/mod/

--- a/commands/theme/mod/remove/index.md
+++ b/commands/theme/mod/remove/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/theme/mod/remove/

--- a/commands/theme/mod/set/index.md
+++ b/commands/theme/mod/set/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/theme/mod/set/

--- a/commands/theme/path/index.md
+++ b/commands/theme/path/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/theme/path/

--- a/commands/theme/search/index.md
+++ b/commands/theme/search/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/theme/search/

--- a/commands/theme/status/index.md
+++ b/commands/theme/status/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/theme/status/

--- a/commands/theme/update-all/index.md
+++ b/commands/theme/update-all/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/theme/update-all/

--- a/commands/theme/update/index.md
+++ b/commands/theme/update/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/theme/update/

--- a/commands/transient/delete/index.md
+++ b/commands/transient/delete/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/transient/delete/

--- a/commands/transient/get/index.md
+++ b/commands/transient/get/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/transient/get/

--- a/commands/transient/index.md
+++ b/commands/transient/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/transient/

--- a/commands/transient/set/index.md
+++ b/commands/transient/set/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/transient/set/

--- a/commands/transient/type/index.md
+++ b/commands/transient/type/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/transient/type/

--- a/commands/user/add-cap/index.md
+++ b/commands/user/add-cap/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/user/add-cap/

--- a/commands/user/add-role/index.md
+++ b/commands/user/add-role/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/user/add-role/

--- a/commands/user/create/index.md
+++ b/commands/user/create/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/user/create/

--- a/commands/user/delete/index.md
+++ b/commands/user/delete/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/user/delete/

--- a/commands/user/generate/index.md
+++ b/commands/user/generate/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/user/generate/

--- a/commands/user/get/index.md
+++ b/commands/user/get/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/user/get/

--- a/commands/user/import-csv/index.md
+++ b/commands/user/import-csv/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/user/import-csv/

--- a/commands/user/index.md
+++ b/commands/user/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/user/

--- a/commands/user/list-caps/index.md
+++ b/commands/user/list-caps/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/user/list-caps/

--- a/commands/user/list/index.md
+++ b/commands/user/list/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/user/list/

--- a/commands/user/meta/add/index.md
+++ b/commands/user/meta/add/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/user/meta/add/

--- a/commands/user/meta/delete/index.md
+++ b/commands/user/meta/delete/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/user/meta/delete/

--- a/commands/user/meta/get/index.md
+++ b/commands/user/meta/get/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/user/meta/get/

--- a/commands/user/meta/index.md
+++ b/commands/user/meta/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/user/meta/

--- a/commands/user/meta/list/index.md
+++ b/commands/user/meta/list/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/user/meta/list/

--- a/commands/user/meta/update/index.md
+++ b/commands/user/meta/update/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/user/meta/update/

--- a/commands/user/remove-cap/index.md
+++ b/commands/user/remove-cap/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/user/remove-cap/

--- a/commands/user/remove-role/index.md
+++ b/commands/user/remove-role/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/user/remove-role/

--- a/commands/user/session/destroy/index.md
+++ b/commands/user/session/destroy/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/user/session/destroy/

--- a/commands/user/session/index.md
+++ b/commands/user/session/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/user/session/

--- a/commands/user/session/list/index.md
+++ b/commands/user/session/list/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/user/session/list/

--- a/commands/user/set-role/index.md
+++ b/commands/user/set-role/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/user/set-role/

--- a/commands/user/term/add/index.md
+++ b/commands/user/term/add/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/user/term/add/

--- a/commands/user/term/index.md
+++ b/commands/user/term/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/user/term/

--- a/commands/user/term/list/index.md
+++ b/commands/user/term/list/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/user/term/list/

--- a/commands/user/term/remove/index.md
+++ b/commands/user/term/remove/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/user/term/remove/

--- a/commands/user/term/set/index.md
+++ b/commands/user/term/set/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/user/term/set/

--- a/commands/user/update/index.md
+++ b/commands/user/update/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/user/update/

--- a/commands/widget/add/index.md
+++ b/commands/widget/add/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/widget/add/

--- a/commands/widget/deactivate/index.md
+++ b/commands/widget/deactivate/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/widget/deactivate/

--- a/commands/widget/delete/index.md
+++ b/commands/widget/delete/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/widget/delete/

--- a/commands/widget/index.md
+++ b/commands/widget/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/widget/

--- a/commands/widget/list/index.md
+++ b/commands/widget/list/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/widget/list/

--- a/commands/widget/move/index.md
+++ b/commands/widget/move/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/widget/move/

--- a/commands/widget/reset/index.md
+++ b/commands/widget/reset/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/widget/reset/

--- a/commands/widget/update/index.md
+++ b/commands/widget/update/index.md
@@ -1,0 +1,2 @@
+redirect_to:
+  - https://developer.wordpress.org/cli/commands/widget/update/


### PR DESCRIPTION
First, I ran:

```
git show --stat 55191a4812e7f44abfc4d3b1281f0be910d3faaf > pages.diff
```

Next, I wrote a little script to create pages from the diff:

```php
<?php

$contents = file_get_contents( 'pages.diff' );
$bits = explode( PHP_EOL, $contents );
foreach ( $bits as $line ) {
	if ( false === stripos( $line, '.md' ) ) {
		continue;
	}
	$line_bits = explode( '.md', $line );
	$file_path = $line_bits[0] . '.md';
	$dir_path  = dirname( $file_path );
	if ( ! is_dir( $dir_path ) ) {
		mkdir( $dir_path, 0777, true );
	}
	$file_contents = <<<EOT
redirect_to:
  - https://developer.wordpress.org/cli/{$dir_path}/
EOT;
	file_put_contents( $file_path, $file_contents );
}
```

Lastly, I ran:

```
wp --skip-wordpress eval-file gen-pages.php
```