### PR TITLE
Fix required PHP version

### DIFF
--- a/index.md
+++ b/index.md
@@ -52,7 +52,7 @@ Downloading the Phar file is our recommended installation method for most users.
 Before installing WP-CLI, please make sure your environment meets the minimum requirements:
 
 - UNIX-like environment (OS X, Linux, FreeBSD, Cygwin); limited support in Windows environment
-- PHP 5.4 or later
+- PHP 5.6 or later
 - WordPress 3.7 or later. Versions older than the latest WordPress release may have degraded functionality
 
 Once you've verified requirements, download the [wp-cli.phar](https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar) file using `wget` or `curl`:

--- a/ja/index.md
+++ b/ja/index.md
@@ -57,7 +57,7 @@ Phar ファイルのダウンロードによるインストールを推奨しま
 WP-CLI をインストールする前に、動作環境を確認してください。
 
 - UNIX 系の環境 (OS X, Linux, FreeBSD, Cygwin) ; Windows では一部の機能に制限があります。
-- PHP 5.4 またはそれ以降のバージョン
+- PHP 5.6 またはそれ以降のバージョン
 - WordPress 3.7 またはそれ以降のバージョン。WordPress 最新版ではない古いバージョンでは、機能が低下する可能性があります。
 
 動作条件を再度確認してから、`wget` または `curl` を使用して [wp-cli.phar](https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar) をダウンロードしてください。


### PR DESCRIPTION
During the [2.5.0 release](https://github.com/wp-cli/wp-cli.github.com/commit/5abedc35788c22b423c1f7739dd4734ddcdba084), the required PHP version was changed to 5.4. According to [this check](https://github.com/wp-cli/wp-cli/blob/v2.5.0/php/boot-fs.php#L10 (props to @wojsmol on slack for pointing me to it), we are really requiring 5.6.

This PR changes it in the main index and also in the Japanese translation, the only one that followed the change so far.